### PR TITLE
[Fix]: fix importlib issue and hf internlm

### DIFF
--- a/examples/hf_react_example.py
+++ b/examples/hf_react_example.py
@@ -4,7 +4,7 @@ from lagent.agents.react import ReAct
 from lagent.llms.huggingface import HFTransformer
 
 model = HFTransformer(
-    path='internlm/internlm-chat-7b-v1.1',
+    path='internlm/internlm-chat-7b-v1_1',
     meta_template=[
         dict(role='system', begin='<|System|>:', end='<TOKENS_UNUSED_2>\n'),
         dict(role='user', begin='<|User|>:', end='<eoh>\n'),

--- a/lagent/utils/package.py
+++ b/lagent/utils/package.py
@@ -1,8 +1,8 @@
-import importlib
+from importlib.util import find_spec
 
 
 def is_module_exist(module_name):
-    spec = importlib.util.find_spec(module_name)
+    spec = find_spec(module_name)
     if spec is None:
         return False
     else:


### PR DESCRIPTION

- `importlib.util.find_spec` will cause `no module named 'util'` error in python 3.10
- huggingface example should be updated by internlm-chat-7b-v1_1