### PR TITLE
Fix the potential keyerror

### DIFF
--- a/lagent/llms/base_api.py
+++ b/lagent/llms/base_api.py
@@ -201,10 +201,12 @@ class APITemplateParser:
 
     def _role2api_role(self, role_prompt: Dict) -> Tuple[str, bool]:
 
-        merged_prompt = self.roles.get(
-            role_prompt['role'],
-            self.roles.get(
-                self.roles[role_prompt['role']].get('fallback_role')))
+        if role_prompt['role'] in self.roles:
+            merged_prompt = self.roles[role_prompt['role']]
+        else:
+            # TODO
+            merged_prompt = self.roles['fallback_role']
+        
         res = {}
         res['role'] = merged_prompt['api_role']
         res['content'] = merged_prompt.get('begin', '')

--- a/lagent/llms/base_llm.py
+++ b/lagent/llms/base_llm.py
@@ -132,9 +132,13 @@ class LMTemplateParser:
                     last: bool = False) -> Tuple[str, bool]:
         if isinstance(prompt, str):
             return prompt
-        merged_prompt = self.roles.get(
-            prompt['role'],
-            self.roles.get(self.roles[prompt['role']].get('fallback_role')))
+        
+        if prompt['role'] in self.roles:
+            merged_prompt = self.roles[prompt['role']]
+        else:
+            # TODO
+            merged_prompt = self.roles['fallback_role']
+
         res = merged_prompt.get('begin', '')
         if last and merged_prompt.get('generate', False):
             res += prompt.get('content', '')


### PR DESCRIPTION
If `prompt['role']` not in `self.roles`, the `self.roles[prompt['role']` will throw a `KeyError`.