### PR TITLE
build: remove unnecessary depc in runtime

### DIFF
--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -1,3 +1,5 @@
+arxiv
+duckduckgo_search==5.3.1b1
 google-search-results
 lmdeploy>=0.2.3
 pillow

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,4 +1,3 @@
-arxiv
 distro
 filelock
 func_timeout
@@ -13,4 +12,3 @@ streamlit
 tiktoken
 timeout-decorator
 typing-extensions
-duckduckgo_search==5.3.1b1


### PR DESCRIPTION
For a lightweight framework, unnecessary dependencies should be avoided as much as possible.