### PR TITLE
Added Ollama support

### DIFF
--- a/lagent/llms/__init__.py
+++ b/lagent/llms/__init__.py
@@ -5,9 +5,11 @@ from .lmdeploy_wrapper import LMDeployClient, LMDeployPipeline, LMDeployServer
 from .meta_template import INTERNLM2_META
 from .openai import GPTAPI
 from .vllm_wrapper import VllmModel
+from .ollama import OllamaAPI
 
 __all__ = [
     'BaseModel', 'BaseAPIModel', 'GPTAPI', 'LMDeployClient',
     'LMDeployPipeline', 'LMDeployServer', 'HFTransformer',
-    'HFTransformerCasualLM', 'INTERNLM2_META', 'HFTransformerChat', 'VllmModel'
+    'HFTransformerCasualLM', 'INTERNLM2_META', 'HFTransformerChat', 'VllmModel',
+    'OllamaAPI'
 ]

--- a/lagent/llms/ollama.py
+++ b/lagent/llms/ollama.py
@@ -1,0 +1,118 @@
+import json
+import requests
+from typing import Dict, List, Optional, Union
+from threading import Lock
+
+class OllamaAPI:
+    def __init__(self, model_type: str, api_base: str = 'http://localhost:11434/v1/chat/completions'):
+        """
+        Initializes an instance of the Ollama class.
+
+        Args:
+            model_type (str): The type of the model.
+            api_base (str, optional): The base URL for the API. Defaults to 'http://localhost:11434/v1/chat/completions'.
+        """
+        self.model_type = model_type
+        self.api_base = api_base
+        self.lock = Lock()
+
+    def _prepare_messages(self, inputs: Union[str, Dict, List[Dict]]) -> List[Dict]:
+        """
+        Prepare messages for processing.
+
+        Args:
+            inputs (Union[str, Dict, List[Dict]]): The input messages to be prepared.
+
+        Returns:
+            List[Dict]: The prepared messages.
+
+        Raises:
+            ValueError: If the inputs are not of the expected types.
+
+        """
+        if isinstance(inputs, str):
+            return [{"role": "user", "content": inputs}]
+        elif isinstance(inputs, dict):
+            return [inputs]
+        elif isinstance(inputs, list) and all(isinstance(m, dict) for m in inputs):
+            return inputs
+        else:
+            raise ValueError("inputs must be a string, a dictionary, or a list of dictionaries")
+
+    def _make_request(self, messages: List[Dict], stream: bool = False, **gen_params) -> requests.Response:
+        """
+        Makes a request to the API endpoint with the given messages.
+        Args:
+            messages (List[Dict]): A list of dictionaries representing the messages to send.
+            stream (bool, optional): Indicates whether the response should be streamed. Defaults to False.
+            **gen_params: Additional parameters to include in the request payload.
+        Returns:
+            requests.Response: The response object returned by the API.
+        Raises:
+            requests.HTTPError: If the API request fails.
+        """
+        payload = {
+            "model": self.model_type,
+            "messages": messages,
+            "stream": stream,
+            **gen_params
+        }
+        
+        with self.lock:
+            response = requests.post(
+                self.api_base,
+                headers={'Content-Type': 'application/json'},
+                json=payload,
+                stream=stream
+            )
+            response.raise_for_status()
+            return response
+
+    def chat(self, inputs: Union[str, Dict, List[Dict]], **gen_params) -> str:
+        """
+        Sends a chat request to the Ollama API and returns the response message content.
+
+        Parameters:
+            inputs (Union[str, Dict, List[Dict]]): The input message(s) to send to the API. It can be a string, a dictionary, or a list of dictionaries.
+            **gen_params: Additional parameters to customize the chat generation.
+
+        Returns:
+            str: The content of the response message.
+
+        Raises:
+            requests.RequestException: If an error occurs while calling the Ollama API.
+
+        """
+        messages = self._prepare_messages(inputs)
+        try:
+            response = self._make_request(messages, **gen_params)
+            return response.json()['choices'][0]['message']['content']
+        except requests.RequestException as e:
+            print(f"Error occurred while calling Ollama API: {e}")
+            return ""
+
+    def stream_chat(self, inputs: Union[str, Dict, List[Dict]], **gen_params):
+        """
+        Streams chat messages and yields the content of each message.
+
+        Args:
+            inputs (Union[str, Dict, List[Dict]]): The input messages to be streamed.
+            **gen_params: Additional parameters for generating the request.
+
+        Yields:
+            str: The content of each chat message.
+
+        Raises:
+            requests.RequestException: If an error occurs while streaming from the Ollama API.
+        """
+        messages = self._prepare_messages(inputs)
+        try:
+            response = self._make_request(messages, stream=True, **gen_params)
+            for line in response.iter_lines():
+                if line:
+                    content = json.loads(line.decode('utf-8'))['choices'][0]['delta'].get('content', '')
+                    if content:
+                        yield content
+        except requests.RequestException as e:
+            print(f"Error occurred while streaming from Ollama API: {e}")
+            yield ""


### PR DESCRIPTION
Added support for Ollama and local models.  Example usage:

from lagent.actions import ActionExecutor, ArxivSearch, IPythonInterpreter
from lagent.agents.react import ReAct
from lagent.llms.ollama import OllamaAPI


llm = OllamaAPI(model_type="llama3.1:8b-instruct-q8_0")


def main():
    llm = OllamaAPI(model_type="llama3.1:8b-instruct-q8_0")
    arxiv_search = ArxivSearch()
    python_interpreter = IPythonInterpreter()
    action_executor = ActionExecutor(actions=[arxiv_search, python_interpreter])
    
    agent = ReAct(llm=llm, action_executor=action_executor)
    
    task = """
    Search for recent papers about computer vision on arXiv and summarize the top 3 results.
    Use the ArxivSearch tool to find papers and the IPythonInterpreter to process the results if needed.
    """
    
    try:
        response = agent.chat(task)
        
        print("Final Response:")
        print(response.response)
        
        print("\nIntermediate Steps:")
        for step in response.inner_steps:
            print(f"Role: {step['role']}")
            print(f"Content: {step['content']}\n")
    except Exception as e:
        print(f"An error occurred: {e}")

if __name__ == "__main__":
    main()