### PR TITLE
[Fix] Fix griffe version

### DIFF
--- a/lagent/actions/base_action.py
+++ b/lagent/actions/base_action.py
@@ -12,7 +12,12 @@ except ImportError:
     from typing_extensions import Annotated
 
 from class_registry import AutoRegister, ClassRegistry
-from griffe import Docstring, DocstringSectionKind
+from griffe import Docstring
+
+try:
+    from griffe.enumerations import DocstringSectionKind
+except ImportError:
+    from griffe import DocstringSectionKind
 
 from ..schema import ActionReturn, ActionStatusCode
 from .parser import BaseParser, JsonParser, ParseError

--- a/lagent/actions/base_action.py
+++ b/lagent/actions/base_action.py
@@ -15,9 +15,9 @@ from class_registry import AutoRegister, ClassRegistry
 from griffe import Docstring
 
 try:
-    from griffe.enumerations import DocstringSectionKind
-except ImportError:
     from griffe import DocstringSectionKind
+except ImportError:
+    from griffe.enumerations import DocstringSectionKind
 
 from ..schema import ActionReturn, ActionStatusCode
 from .parser import BaseParser, JsonParser, ParseError

--- a/lagent/actions/base_action.py
+++ b/lagent/actions/base_action.py
@@ -12,8 +12,7 @@ except ImportError:
     from typing_extensions import Annotated
 
 from class_registry import AutoRegister, ClassRegistry
-from griffe import Docstring
-from griffe.enumerations import DocstringSectionKind
+from griffe import Docstring, DocstringSectionKind
 
 from ..schema import ActionReturn, ActionStatusCode
 from .parser import BaseParser, JsonParser, ParseError


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/6f66d8cb-b451-4764-9aab-fcd6f34fc2bf)

由于 griffe1.0.0 移除了 griffe.enumerations，所以需要修改此处 import。

两种修改方法：

1. 判断 griffe 版本，如果是 1.x，则直接 import；如果是 0.x，保持原 import 方法。
2. 直接 import。

本 PR 目前使用了第二种方法。如果佬们觉得第一种方法更合适，可以留下 comment，我来修改为第一种。