### PR TITLE
Add class_registry to runtime requirements

### DIFF
--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -14,3 +14,4 @@ tiktoken
 timeout-decorator
 typing-extensions
 duckduckgo_search==5.3.1b1
+class_registry


### PR DESCRIPTION
# Add class_registry to runtime requirements

In the MindSearch project, I discovered that after installing dependencies using `pip install git+https://github.com/InternLM/lagent.git` via Docker, the project still lacked class_registry when running.

Upon investigation, I determined that class_registry is a new runtime dependency that had not been updated in the requirements.txt file.

This PR adds class_registry to the requirements.txt file to ensure all necessary dependencies are properly installed, thus preventing missing dependency issues during runtime.

# 更新 requirements.txt 以包含 class_registry

在 MindSearch 项目中，我发现通过 Docker 使用 `pip install git+https://github.com/InternLM/lagent.git` 安装依赖后，运行项目时仍然缺少 class_registry。

经过调查，我确定 class_registry 是一个新增的运行时依赖，但未被更新到 requirements.txt 中。

这个 PR 将 class_registry 添加到 requirements.txt 文件中，以确保所有必要的依赖都被正确安装，从而避免运行时出现缺少依赖的问题。