### PR TITLE
添加searxng搜索引擎支持

### DIFF
--- a/lagent/actions/web_browser.py
+++ b/lagent/actions/web_browser.py
@@ -286,10 +286,10 @@ class SearxngSearch(BaseSearch):
     def _call_searxng_api(self, query: str) -> dict:
         # params = {'q': query, 'mkt': self.market, 'count': f'{self.topk * 2}'}
         params = {
-            'q': query,  # 搜索查询
-            'categories': self.categories,  # 搜索类别
-            'language': self.language,  # 语言
-            'format': 'json',  # 输出格式
+            'q': query,  #
+            'categories': self.categories,
+            'language': self.language,
+            'format': 'json',
             'count': f'{self.topk * 2}',
         }
         headers = {self.auth_name: self.api_key or ''}
@@ -299,10 +299,10 @@ class SearxngSearch(BaseSearch):
 
     async def _async_call_searxng_api(self, query: str) -> dict:
         params = {
-            'q': query,  # 搜索查询
-            'categories': self.categories,  # 搜索类别
-            'language': self.language,  # 语言
-            'format': 'json',  # 输出格式
+            'q': query,  # question
+            'categories': self.categories,  # categories
+            'language': self.language,  # language
+            'format': 'json',  # format
             'count': f'{self.topk * 2}',
         }
         headers = {self.auth_name: self.api_key or ''}
@@ -906,14 +906,6 @@ class WebBrowser(BaseAction):
             return {'error': web_content}
 
 
-async def main():
-    search_tool = SearxngSearch(api_key='abc')
-    # search_tool = DuckDuckGoSearch(proxy= 'http://192.168.26.xxx:7890')
-    tool_return = await search_tool.asearch("What's the capital of China?")
-    for key, value in tool_return.items():
-        print(f'{key}: {value}')
-
-
 class AsyncWebBrowser(AsyncActionMixin, WebBrowser):
     """Wrapper around the Web Browser Tool."""
 
@@ -986,11 +978,3 @@ class AsyncWebBrowser(AsyncActionMixin, WebBrowser):
             return {'type': 'text', 'content': web_content}
         else:
             return {'error': web_content}
-
-
-if __name__ == '__main__':
-    os.environ['SEARXNG_URL'] = 'http://192.168.26.xxx:18080/search'
-    # tool_return =  search_tool.search("What's the capital of China?")
-    # for key, value in tool_return.items():
-    #     print(f"{key}: {value}")
-    asyncio.run(main())

--- a/lagent/actions/web_browser.py
+++ b/lagent/actions/web_browser.py
@@ -207,27 +207,27 @@ import os
 
 class SearxngSearch(BaseSearch):
     """
-    创建SearXNG客户端。
-    （PS： 1. 首先自建SearXNG搜索引擎服务端：https://docs.searxng.org/
-     2、 如果是SearXNG等不需要apiKey的服务端，则auth_name、api_key不需要关注
-     3、如果需要传apiKey的服务端，auth_name为header中的key值，api_key为value值。当然这里入参param还没支持自定义）
+    Create a SearXNG client.
+    (PS: 1. First, set up your own SearXNG search engine server: https://docs.searxng.org/
+     2. For servers like SearXNG that do not require an apiKey, you don't need to concern yourself with auth_name and api_key.
+     3. For servers that require passing an apiKey, auth_name would be the key in the header, and api_key would be the value. Note that custom parameters are not yet supported for input.)
 
-     SearXNG之类不需要鉴权的搜索引擎服务端：
-      需要设置服务端地址：两种方式：
-        方式一：环境变量：export SEARXNG_URL="http://192.168.26.xxx:18080/search"
-        方式二：初始化SearxngSearch时赋值url； tool = SearxngSearch(url="")
-        若两者都设置，以方式一的值为准
-      需要鉴权的搜索引擎服务端：
-        略
+    For SearXNG-like search engine servers that do not require authentication:
+      You need to set the server address in one of two ways:
+        Method One: Environment variable: export SEARXNG_URL="http://192.168.26.xxx:18080/search"
+        Method Two: Assign the URL when initializing SearxngSearch: tool = SearxngSearch(url="")
+        If both methods are used, the value from method one takes precedence.
+    For search engine servers that require authentication:
+      Omitted
     Args:
-        api_key (str): API密钥，默认值为'sk-xxxx'。
-        auth_name (str): 认证名称，默认值为'searxng'。
-        language (str): 语言设置，默认值为'zh'。
-        categories (str): 类别设置，默认值为'general'。
-        url (str): SearXNG服务的URL，默认值为'http://127.0.0.1:18883'。
-        topk (int): 返回的顶部结果数量，默认值为3。
-        black_list (List[str]): 黑名单列表，包含不希望搜索到的域名。
-        **kwargs: 其他可变关键字参数，如代理设置。
+        api_key (str): API key, default is 'sk-xxxx'.
+        auth_name (str): Authentication name, default is 'searxng'.
+        language (str): Language setting, default is 'zh'.
+        categories (str): Category setting, default is 'general'.
+        url (str): URL of the SearXNG service, default is 'http://127.0.0.1:18883'.
+        topk (int): Number of top results to return, default is 3.
+        black_list (List[str]): Blacklist of domains you do not wish to see in search results.
+        **kwargs: Other variable keyword arguments, such as proxy settings.
     """
 
     def __init__(

--- a/lagent/actions/web_browser.py
+++ b/lagent/actions/web_browser.py
@@ -3,6 +3,7 @@ import hashlib
 import hmac
 import json
 import logging
+import os
 import random
 import re
 import time
@@ -203,14 +204,16 @@ class BingSearch(BaseSearch):
 
         return self._filter_results(raw_results)
 
-import os
 
 class SearxngSearch(BaseSearch):
     """
     Create a SearXNG client.
     (PS: 1. First, set up your own SearXNG search engine server: https://docs.searxng.org/
-     2. For servers like SearXNG that do not require an apiKey, you don't need to concern yourself with auth_name and api_key.
-     3. For servers that require passing an apiKey, auth_name would be the key in the header, and api_key would be the value. Note that custom parameters are not yet supported for input.)
+     2. For servers like SearXNG that do not require an apiKey,
+                you don't need to concern yourself with auth_name and api_key.
+     3. For servers that require passing an apiKey, auth_name would be the key in the header,
+        and api_key would be the value.
+      Note that custom parameters are not yet supported for input.
 
     For SearXNG-like search engine servers that do not require authentication:
       You need to set the server address in one of two ways:
@@ -232,11 +235,11 @@ class SearxngSearch(BaseSearch):
 
     def __init__(
         self,
-        api_key: str='sk-xxxx',
+        api_key: str = 'sk-xxxx',
         auth_name: str = 'searxng',
         language: str = 'zh',
-        categories:str = 'general',
-        url:str="http://127.0.0.1:18883",
+        categories: str = 'general',
+        url: str = 'http://127.0.0.1:18883',
         topk: int = 3,
         black_list: List[str] = [
             'enoN',
@@ -251,8 +254,8 @@ class SearxngSearch(BaseSearch):
         self.language = language
         self.categories = categories
         self.proxy = kwargs.get('proxy')
-        self.SEARXNG_URL = os.getenv("SEARXNG_URL")
-        if self.SEARXNG_URL is None or self.SEARXNG_URL == "":
+        self.SEARXNG_URL = os.getenv('SEARXNG_URL')
+        if self.SEARXNG_URL is None or self.SEARXNG_URL == '':
             self.SEARXNG_URL = url
         super().__init__(topk, black_list)
 
@@ -283,11 +286,11 @@ class SearxngSearch(BaseSearch):
     def _call_searxng_api(self, query: str) -> dict:
         # params = {'q': query, 'mkt': self.market, 'count': f'{self.topk * 2}'}
         params = {
-            "q": query,  # 搜索查询
-            "categories": self.categories,  # 搜索类别
-            "language": self.language,  # 语言
-            "format": "json"  # 输出格式
-            ,'count': f'{self.topk * 2}'
+            'q': query,  # 搜索查询
+            'categories': self.categories,  # 搜索类别
+            'language': self.language,  # 语言
+            'format': 'json',  # 输出格式
+            'count': f'{self.topk * 2}',
         }
         headers = {self.auth_name: self.api_key or ''}
         response = requests.get(self.SEARXNG_URL, headers=headers, params=params, proxies=self.proxy)
@@ -296,11 +299,11 @@ class SearxngSearch(BaseSearch):
 
     async def _async_call_searxng_api(self, query: str) -> dict:
         params = {
-            "q": query,  # 搜索查询
-            "categories": self.categories,  # 搜索类别
-            "language": self.language,  # 语言
-            "format": "json"  # 输出格式
-            , 'count': f'{self.topk * 2}'
+            'q': query,  # 搜索查询
+            'categories': self.categories,  # 搜索类别
+            'language': self.language,  # 语言
+            'format': 'json',  # 输出格式
+            'count': f'{self.topk * 2}',
         }
         headers = {self.auth_name: self.api_key or ''}
         async with aiohttp.ClientSession(raise_for_status=True) as session:
@@ -315,13 +318,14 @@ class SearxngSearch(BaseSearch):
     def _parse_response(self, response: dict) -> dict:
         raw_results = []
 
-        for result in response["results"]:
-            title = result["title"]
-            url = result["url"]
-            content = result["content"]
+        for result in response['results']:
+            title = result['title']
+            url = result['url']
+            content = result['content']
             raw_results.append((url, content, title))
 
         return self._filter_results(raw_results)
+
 
 class BraveSearch(BaseSearch):
     """
@@ -901,14 +905,15 @@ class WebBrowser(BaseAction):
         else:
             return {'error': web_content}
 
-import asyncio
 
 async def main():
     search_tool = SearxngSearch(api_key='abc')
     # search_tool = DuckDuckGoSearch(proxy= 'http://192.168.26.xxx:7890')
     tool_return = await search_tool.asearch("What's the capital of China?")
     for key, value in tool_return.items():
-        print(f"{key}: {value}")
+        print(f'{key}: {value}')
+
+
 class AsyncWebBrowser(AsyncActionMixin, WebBrowser):
     """Wrapper around the Web Browser Tool."""
 
@@ -981,8 +986,10 @@ class AsyncWebBrowser(AsyncActionMixin, WebBrowser):
             return {'type': 'text', 'content': web_content}
         else:
             return {'error': web_content}
+
+
 if __name__ == '__main__':
-    os.environ['SEARXNG_URL'] = "http://192.168.26.xxx:18080/search"
+    os.environ['SEARXNG_URL'] = 'http://192.168.26.xxx:18080/search'
     # tool_return =  search_tool.search("What's the capital of China?")
     # for key, value in tool_return.items():
     #     print(f"{key}: {value}")

--- a/tests/test_actions/test_searxng_search.py
+++ b/tests/test_actions/test_searxng_search.py
@@ -1,8 +1,7 @@
-import json
+import os
 from unittest import TestCase, mock
 
 from lagent.actions.web_browser import SearxngSearch
-from lagent.schema import ActionStatusCode
 
 
 class TestGoogleSearch(TestCase):
@@ -11,9 +10,8 @@ class TestGoogleSearch(TestCase):
     def test_search_tool(self, mock_search_func):
         # mock_response = (200, json.load('tests/data/search.json'))
         # mock_search_func.return_value = mock_response
-        import os
-        os.environ['SEARXNG_URL'] = "http://192.168.26.xx:18080/search"
+
+        os.environ['SEARXNG_URL'] = 'http://192.168.26.xx:18080/search'
         search_tool = SearxngSearch(api_key='abc')
         tool_return = search_tool.search("What's the capital of China?")
         self.assertGreater(len(tool_return), 0)
-

--- a/tests/test_actions/test_searxng_search.py
+++ b/tests/test_actions/test_searxng_search.py
@@ -1,0 +1,19 @@
+import json
+from unittest import TestCase, mock
+
+from lagent.actions.web_browser import SearxngSearch
+from lagent.schema import ActionStatusCode
+
+
+class TestGoogleSearch(TestCase):
+
+    @mock.patch.object(SearxngSearch, 'search')
+    def test_search_tool(self, mock_search_func):
+        # mock_response = (200, json.load('tests/data/search.json'))
+        # mock_search_func.return_value = mock_response
+        import os
+        os.environ['SEARXNG_URL'] = "http://192.168.26.xx:18080/search"
+        search_tool = SearxngSearch(api_key='abc')
+        tool_return = search_tool.search("What's the capital of China?")
+        self.assertGreater(len(tool_return), 0)
+


### PR DESCRIPTION
支持searxng搜索引擎。
lagent和mindsearch都已测试通过：
lagent测试：
![lagent-1](https://github.com/user-attachments/assets/40664b21-377c-4d7d-bcbe-aa13fe94c47a)
mindsearch测试：
![lagent-mindsearch](https://github.com/user-attachments/assets/235a2bdb-e79d-450b-a0ef-d461924391fa)
