### PR TITLE
 Refactor agent loop output protocol on AgentMessage 

### DIFF
--- a/lagent/actions/mcp_client.py
+++ b/lagent/actions/mcp_client.py
@@ -1,5 +1,4 @@
 import asyncio
-import logging
 import random
 import threading
 import time
@@ -11,11 +10,12 @@ from typing import Literal, Optional, TypeAlias
 from lagent.actions.base_action import AsyncActionMixin, BaseAction
 from lagent.actions.parser import JsonParser, ParseError
 from lagent.schema import ActionReturn, ActionStatusCode
+from lagent.utils import get_logger
 from lagent.utils.rate_limiter import FairAsyncTokenBucket, get_shared_async_token_bucket
 
 ServerType: TypeAlias = Literal['stdio', 'sse', 'http']
 
-logger = logging.getLogger(__name__)
+logger = get_logger()
 _loop = None
 
 warnings.filterwarnings('ignore', category=ResourceWarning, module=r'aiohttp\.client')
@@ -24,12 +24,6 @@ warnings.filterwarnings('ignore', category=ResourceWarning, module=r'anyio\._bac
 _failure_log_lock = threading.Lock()
 _failure_log_last: dict[tuple[str, str, str], float] = {}
 _FAILURE_LOG_INTERVAL_S = 60.0
-
-
-def _warning_without_resource_warning(msg: str, *args) -> None:
-    with warnings.catch_warnings():
-        warnings.simplefilter('ignore', ResourceWarning)
-        logger.warning(msg, *args)
 
 
 def _log_action_failure(action_name: str, exc: Exception) -> None:
@@ -53,7 +47,7 @@ def _log_action_failure(action_name: str, exc: Exception) -> None:
         if now - last < _FAILURE_LOG_INTERVAL_S:
             return
         _failure_log_last[key] = now
-    _warning_without_resource_warning('MCP Action %s failed:\n%s', action_name, detail)
+    logger.warning('MCP Action %s failed:\n%s', action_name, detail)
 
 
 def _get_event_loop():

--- a/lagent/actions/mcp_client.py
+++ b/lagent/actions/mcp_client.py
@@ -3,18 +3,57 @@ import logging
 import random
 import threading
 import time
-from collections import deque
+import warnings
+from concurrent.futures import TimeoutError as FutureTimeoutError
 from contextlib import AsyncExitStack, nullcontext
-from typing import Deque, Literal, Optional, TypeAlias
+from typing import Literal, Optional, TypeAlias
 
 from lagent.actions.base_action import AsyncActionMixin, BaseAction
 from lagent.actions.parser import JsonParser, ParseError
 from lagent.schema import ActionReturn, ActionStatusCode
+from lagent.utils.rate_limiter import FairAsyncTokenBucket, get_shared_async_token_bucket
 
-ServerType: TypeAlias = Literal["stdio", "sse", "http"]
+ServerType: TypeAlias = Literal['stdio', 'sse', 'http']
 
 logger = logging.getLogger(__name__)
 _loop = None
+
+warnings.filterwarnings('ignore', category=ResourceWarning, module=r'aiohttp\.client')
+warnings.filterwarnings('ignore', category=ResourceWarning, module=r'anyio\._backends\._asyncio')
+
+_failure_log_lock = threading.Lock()
+_failure_log_last: dict[tuple[str, str, str], float] = {}
+_FAILURE_LOG_INTERVAL_S = 60.0
+
+
+def _warning_without_resource_warning(msg: str, *args) -> None:
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', ResourceWarning)
+        logger.warning(msg, *args)
+
+
+def _log_action_failure(action_name: str, exc: Exception) -> None:
+    parts = [f"{type(exc).__name__}: {exc}"]
+    # Unwrap ExceptionGroup so the actual sub-exception is visible (anyio TaskGroup
+    # wraps connect/read errors into ExceptionGroup which str()s to a useless summary).
+    pending = list(getattr(exc, 'exceptions', ()) or ())
+    while pending:
+        sub = pending.pop(0)
+        parts.append(f"  -> {type(sub).__name__}: {sub}")
+        pending.extend(getattr(sub, 'exceptions', ()) or ())
+    cause = exc.__cause__ or exc.__context__
+    if cause is not None and cause is not exc:
+        parts.append(f"  caused by {type(cause).__name__}: {cause}")
+    detail = '\n'.join(parts)
+
+    key = (action_name, type(exc).__name__, detail[:256])
+    now = time.monotonic()
+    with _failure_log_lock:
+        last = _failure_log_last.get(key, 0.0)
+        if now - last < _FAILURE_LOG_INTERVAL_S:
+            return
+        _failure_log_last[key] = now
+    _warning_without_resource_warning('MCP Action %s failed:\n%s', action_name, detail)
 
 
 def _get_event_loop():
@@ -42,186 +81,6 @@ def _get_event_loop():
     return event_loop
 
 
-class TokenBucket:
-    def __init__(self, rate_limit: float):
-        self.rate_limit = rate_limit  # tokens per second
-        self.tokens = rate_limit
-        self.last_update = time.time()
-        self.lock = threading.Lock()
-
-    def acquire(self) -> bool:
-        with self.lock:
-            now = time.time()
-            # Add new tokens based on time elapsed
-            new_tokens = (now - self.last_update) * self.rate_limit
-            self.tokens = min(self.rate_limit, self.tokens + new_tokens)
-            self.last_update = now
-
-            if self.tokens >= 1:
-                self.tokens -= 1
-                return True
-            return False
-
-
-class AsyncTokenBucket:
-    def __init__(self, rate_limit: float):
-        self.rate_limit = rate_limit
-        self.capacity = rate_limit
-        self.tokens = rate_limit
-        self.last_update = time.monotonic()
-        self._lock = asyncio.Lock()
-
-    def _refill(self):
-        now = time.monotonic()
-        elapsed = now - self.last_update
-        if elapsed <= 0:
-            return
-        self.tokens = min(self.capacity, self.tokens + elapsed * self.rate_limit)
-        self.last_update = now
-
-    async def acquire(self):
-        while True:
-            async with self._lock:
-                self._refill()
-                if self.tokens >= 1:
-                    self.tokens -= 1
-                    return
-                missing = 1 - self.tokens
-                wait_time = missing / self.rate_limit
-            await asyncio.sleep(wait_time)
-
-
-class FairAsyncTokenBucket:
-    def __init__(self, rate_limit: float, capacity: Optional[float] = None):
-        """
-        rate_limit: 每秒生成多少个 token
-        capacity: 桶容量（最大可累积多少 token），默认和 rate_limit 一样
-        """
-        self.rate_limit = float(rate_limit)
-        self.capacity = float(capacity) if capacity is not None else float(rate_limit)
-
-        self.tokens = self.capacity
-        self.last_update = time.monotonic()
-
-        self._lock = asyncio.Lock()
-        self._waiters: Deque[asyncio.Future] = deque()
-        self._drainer_running = False  # 是否已有后台协程在发 token
-
-    # ---------- 内部工具方法 ----------
-
-    def _refill_unlocked(self) -> None:
-        """
-        在不持锁的前提下不要调用。
-        根据时间流逝计算当前 token 数。
-        """
-        now = time.monotonic()
-        elapsed = now - self.last_update
-        if elapsed <= 0:
-            return
-        self.tokens = min(self.capacity, self.tokens + elapsed * self.rate_limit)
-        self.last_update = now
-
-    async def _drain_waiters(self) -> None:
-        """
-        后台协程：按 FIFO 顺序给排队的协程发 token。
-        - 没 token 时，就 sleep 到下一个 token 产生的时间点。
-        - 有 token 且有排队，就唤醒队头的一个，再继续循环。
-        """
-        try:
-            while True:
-                fut_to_wake: Optional[asyncio.Future] = None
-                sleep_time: Optional[float] = None
-
-                async with self._lock:
-                    self._refill_unlocked()
-
-                    # 队列空了，没什么好做的了，退出 drainer
-                    if not self._waiters:
-                        self._drainer_running = False
-                        return
-
-                    if self.tokens >= 1:
-                        # 有 token，按 FIFO 唤醒一个排队的协程
-                        self.tokens -= 1
-                        fut_to_wake = self._waiters.popleft()
-                        sleep_time = 0.0
-                    else:
-                        # 没 token，算一下距离下一个 token 的时间
-                        missing = 1.0 - self.tokens  # 还差多少 token 才能发下一枚
-                        sleep_time = max(0.0, missing / self.rate_limit)
-
-                # 出锁之后再唤醒，避免在锁里执行用户代码 / 回调
-                if fut_to_wake is not None and not fut_to_wake.done():
-                    fut_to_wake.set_result(None)
-
-                # 如果刚刚唤醒了一个协程，立刻回到循环，看是否还能继续发
-                if sleep_time == 0.0:
-                    continue
-
-                # 没 token，就等到有 token 再继续
-                await asyncio.sleep(sleep_time)
-        finally:
-            # 兜底，避免异常时 drainer_running 一直是 True 导致无法重启
-            async with self._lock:
-                self._drainer_running = False
-
-    # ---------- 对外接口 ----------
-
-    async def acquire(self) -> None:
-        """
-        获取一个 token（公平：排队 FIFO）
-        """
-        loop = asyncio.get_running_loop()
-
-        # 先尝试直接拿 token（快速路径）
-        async with self._lock:
-            self._refill_unlocked()
-
-            # 如果有 token 且没有历史排队的协程，直接拿走返回
-            if self.tokens >= 1 and not self._waiters:
-                self.tokens -= 1
-                return
-
-            # 否则需要排队
-            fut = loop.create_future()
-            self._waiters.append(fut)
-
-            # 启动 drainer（只要一个就够了）
-            if not self._drainer_running:
-                self._drainer_running = True
-                asyncio.create_task(self._drain_waiters())
-
-        # 等待被 drainer 唤醒，唤醒后说明自己拿到了 token
-        await fut
-
-
-# --- 复用你原本的辅助工具 ---
-_loop = None
-
-
-def _get_event_loop():
-    try:
-        event_loop = asyncio.get_event_loop()
-    except Exception:
-        event_loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(event_loop)
-
-    if event_loop.is_running():
-        global _loop
-        if _loop:
-            return _loop
-        from threading import Thread
-
-        def _start_loop(loop):
-            asyncio.set_event_loop(loop)
-            loop.run_forever()
-
-        event_loop = asyncio.new_event_loop()
-        Thread(target=_start_loop, args=(event_loop,), daemon=True).start()
-        _loop = event_loop
-    return event_loop
-
-
 class AsyncMCPClient(AsyncActionMixin, BaseAction):
     """
     Standard Lagent Action that wraps a SINGLE tool from an MCP Server.
@@ -231,13 +90,17 @@ class AsyncMCPClient(AsyncActionMixin, BaseAction):
     This prevents connection leaks and 'ConnectTimeout' in high-concurrency RL environments.
     """
 
-
     def __init__(
         self,
         server_type: ServerType,
         rate_limit: float = None,
+        rate_limit_key: Optional[str] = None,
+        rate_limit_burst: Optional[float] = None,
         max_concurrency: int = None,
-        # 注意：这里的 name 主要用于 Lagent 注册，但工具的实际元数据来自 MCP Server
+        metadata_timeout: Optional[float] = 60.0,
+        call_timeout: Optional[float] = 300.0,
+        description: Optional[dict] = None,
+        # name 保留给旧配置；实际工具名优先来自 description 或 MCP metadata
         name: Optional[str] = None,
         extra_args: Optional[dict] = None,
         **server_params,
@@ -246,34 +109,48 @@ class AsyncMCPClient(AsyncActionMixin, BaseAction):
         self.server_type = server_type
         self.server_params = server_params
         self.extra_args = extra_args or {}
+        self.metadata_timeout = (
+            float(metadata_timeout) if metadata_timeout is not None and metadata_timeout > 0 else None
+        )
+        self.call_timeout = float(call_timeout) if call_timeout is not None and call_timeout > 0 else None
 
         # 并发控制组件
-        self.rate_limiter = FairAsyncTokenBucket(rate_limit) if rate_limit is not None else None
+        if rate_limit is None:
+            self.rate_limiter = None
+        elif rate_limit_key:
+            self.rate_limiter = get_shared_async_token_bucket(rate_limit_key, rate_limit, rate_limit_burst)
+        else:
+            self.rate_limiter = FairAsyncTokenBucket(rate_limit, capacity=rate_limit_burst)
         self._sem = asyncio.Semaphore(max_concurrency) if max_concurrency is not None else nullcontext()
 
-        # 1. 临时连接获取工具元数据 (Metadata)
-        # 必须在 __init__ 完成，因为 Lagent 需要 self.description
-        loop = _get_event_loop()
-        if loop.is_running():
-            fut = asyncio.run_coroutine_threadsafe(self._fetch_tool_metadata(), loop)
-            tools = fut.result()
-        else:
-            tools = loop.run_until_complete(self._fetch_tool_metadata())
+        if description is None:
+            # 临时连接获取工具元数据 (Metadata)。必须在 __init__ 完成，因为 Lagent 需要 self.description。
+            loop = _get_event_loop()
+            if loop.is_running():
+                fut = asyncio.run_coroutine_threadsafe(self._fetch_tool_metadata(), loop)
+                try:
+                    tools = fut.result(timeout=self.metadata_timeout)
+                except FutureTimeoutError as exc:
+                    fut.cancel()
+                    raise TimeoutError(f"Timed out fetching MCP tool metadata after {self.metadata_timeout}s") from exc
+            else:
+                metadata_task = self._fetch_tool_metadata()
+                if self.metadata_timeout is not None:
+                    metadata_task = asyncio.wait_for(metadata_task, timeout=self.metadata_timeout)
+                tools = loop.run_until_complete(metadata_task)
 
-        # Single Action 约束：一个 Action 实例对应一个 MCP 工具
-        if len(tools) != 1:
-            logger.warning(
-                f"MCP Server returned {len(tools)} tools, but AsyncMCPAction is designed for a Single Action. "
-                f"Using the first one: {tools[0].name}"
-            )
+            # Single Action 约束：一个 Action 实例对应一个 MCP 工具
+            if not tools:
+                raise RuntimeError('MCP Server returned no tools.')
+            if len(tools) != 1:
+                logger.warning(
+                    f"MCP Server returned {len(tools)} tools, but AsyncMCPAction is designed for a Single Action. "
+                    f"Using the first one: {tools[0].name}"
+                )
 
-        self.tool_info = tools[0]
-        tool_name = self.tool_info.name
-
-        # 2. 初始化父类 BaseAction
-        super().__init__(
-            description={
-                'name': tool_name,
+            self.tool_info = tools[0]
+            description = {
+                'name': self.tool_info.name,
                 'description': self.tool_info.description,
                 'parameters': [
                     {'name': k, 'type': v['type'].upper(), 'description': v.get('description', '')}
@@ -281,7 +158,28 @@ class AsyncMCPClient(AsyncActionMixin, BaseAction):
                     if k not in self.extra_args
                 ],
                 'required': self.tool_info.inputSchema.get('required', []),
-            },
+            }
+        else:
+            description = dict(description)
+            if 'name' not in description:
+                if name is None:
+                    raise ValueError('Static MCP action description must include a tool name.')
+                description['name'] = name
+            self.tool_info = None
+
+        self.tool_name = description['name']
+        if self.extra_args:
+            description = {
+                **description,
+                'parameters': [
+                    param for param in description.get('parameters', []) if param.get('name') not in self.extra_args
+                ],
+                'required': [item for item in description.get('required', []) if item not in self.extra_args],
+            }
+
+        # 2. 初始化父类 BaseAction
+        super().__init__(
+            description=description,
             parser=JsonParser,
         )
         self._is_toolkit = False
@@ -294,46 +192,46 @@ class AsyncMCPClient(AsyncActionMixin, BaseAction):
         from mcp import ClientSession, StdioServerParameters
 
         # --- Transport Layer ---
-        if self.server_type == "stdio":
+        if self.server_type == 'stdio':
             from mcp.client.stdio import stdio_client
 
             logger.info(
                 f"Connecting to stdio MCP server with command: {self.server_params['command']} "
                 f"{self.server_params.get('args', [])}"
             )
-            client_kwargs = {"command": self.server_params["command"]}
-            for key in ["args", "env", "cwd"]:
+            client_kwargs = {'command': self.server_params['command']}
+            for key in ['args', 'env', 'cwd']:
                 if self.server_params.get(key) is not None:
                     client_kwargs[key] = self.server_params[key]
 
             server_params_obj = StdioServerParameters(**client_kwargs)
             read, write = await stack.enter_async_context(stdio_client(server_params_obj))
 
-        elif self.server_type == "sse":
+        elif self.server_type == 'sse':
             from mcp.client.sse import sse_client
 
             logger.info(f"Connecting to SSE MCP server at: {self.server_params['url']}")
 
-            url = self.server_params["url"]
+            url = self.server_params['url']
             target_url = random.choice(url) if isinstance(url, list) else url
 
-            client_kwargs = {"url": target_url}
-            for key in ["headers", "timeout", "sse_read_timeout"]:
+            client_kwargs = {'url': target_url}
+            for key in ['headers', 'timeout', 'sse_read_timeout']:
                 if self.server_params.get(key) is not None:
                     client_kwargs[key] = self.server_params[key]
 
             read, write = await stack.enter_async_context(sse_client(**client_kwargs))
 
-        elif self.server_type == "http":
+        elif self.server_type == 'http':
             from mcp.client.streamable_http import streamablehttp_client
 
             # logger.debug(f"Connecting to StreamableHTTP MCP server at: {self.server_params['url']}")
 
-            url = self.server_params["url"]
+            url = self.server_params['url']
             target_url = random.choice(url) if isinstance(url, list) else url
 
-            client_kwargs = {"url": target_url}
-            for key in ["headers", "timeout", "sse_read_timeout", "terminate_on_close"]:
+            client_kwargs = {'url': target_url}
+            for key in ['headers', 'timeout', 'sse_read_timeout', 'terminate_on_close']:
                 if self.server_params.get(key) is not None:
                     client_kwargs[key] = self.server_params[key]
 
@@ -354,6 +252,15 @@ class AsyncMCPClient(AsyncActionMixin, BaseAction):
             result = await session.list_tools()
             return result.tools
 
+    async def _call_tool_once(self, kwargs: dict):
+        async with AsyncExitStack() as stack:
+            session = await self._connect(stack)
+            outputs_obj = await session.call_tool(self.tool_name, {**kwargs, **self.extra_args})
+
+            if outputs_obj.content and hasattr(outputs_obj.content[0], 'text'):
+                return outputs_obj.content[0].text
+            return str(outputs_obj)
+
     async def run(self, **kwargs) -> ActionReturn:
         """
         Standard Lagent Action Entrypoint.
@@ -366,26 +273,15 @@ class AsyncMCPClient(AsyncActionMixin, BaseAction):
                 if self.rate_limiter is not None:
                     await self.rate_limiter.acquire()
 
-                # 2. 执行逻辑 (Critical Resource Scope)
-                # 使用 AsyncExitStack 确保本次请求结束后，HTTP连接/进程管道被彻底关闭
-                async with AsyncExitStack() as stack:
-                    session = await self._connect(stack)
-
-                    # 调用 MCP 工具
-                    # 注意：Lagent 传入的是 kwargs 字典，MCP call_tool 正好接受字典
-                    outputs_obj = await session.call_tool(self.tool_info.name, {**kwargs, **self.extra_args})
-
-                    # 提取文本结果
-                    if outputs_obj.content and hasattr(outputs_obj.content[0], 'text'):
-                        outputs = outputs_obj.content[0].text
-                    else:
-                        outputs = str(outputs_obj)
+                call_task = self._call_tool_once(kwargs)
+                if self.call_timeout is not None:
+                    call_task = asyncio.wait_for(call_task, timeout=self.call_timeout)
+                outputs = await call_task
 
         except ParseError as exc:
             return ActionReturn(fallback_args, type=self.name, errmsg=exc.err_msg, state=ActionStatusCode.ARGS_ERROR)
         except Exception as exc:
-            # 记录详细堆栈以便调试 RL 过程中的错误
-            logger.warning(f"MCP Action {self.name} failed: {exc}")
+            _log_action_failure(self.name, exc)
             return ActionReturn(fallback_args, type=self.name, errmsg=str(exc), state=ActionStatusCode.API_ERROR)
 
         # 3. 结果封装

--- a/lagent/agents/agent.py
+++ b/lagent/agents/agent.py
@@ -1,4 +1,5 @@
 import copy
+import inspect
 import warnings
 from collections import OrderedDict, UserDict, UserList, abc
 from functools import wraps
@@ -13,6 +14,20 @@ from lagent.prompts.parsers import StrParser
 from lagent.prompts.prompt_template import PromptTemplate
 from lagent.schema import AgentMessage, ModelStatusCode
 from lagent.utils import create_object
+
+
+async def _maybe_close(obj) -> None:
+    """Best-effort close: invoke ``aclose`` / ``close`` on any object that has one."""
+    if obj is None:
+        return
+    for name in ('aclose', 'close'):
+        method = getattr(obj, name, None)
+        if method is None:
+            continue
+        result = method()
+        if inspect.isawaitable(result):
+            await result
+        return
 
 
 class Agent:
@@ -105,7 +120,7 @@ class Agent:
             destination.update({prefix + 'memory': saved_memory})
         for name, agent in getattr(self, '_agents', {}).items():
             if isinstance(agent, Agent):
-                agent.state_dict(destination=destination, prefix=prefix + name + ".")
+                agent.state_dict(destination=destination, prefix=prefix + name + '.')
         return destination
 
     def load_state_dict(self, state_dict: Dict):
@@ -150,6 +165,18 @@ class Agent:
             if recursive:
                 for agent in getattr(self, '_agents', {}).values():
                     agent.reset(recursive=True)
+
+    async def close(self, recursive: bool = True) -> None:
+        """Release resources held by this agent.
+
+        The default implementation closes all sub-agents collected in
+        ``self._agents``. Subclasses that own their own resources (actions,
+        sessions, connection pools, ...) should override this, do their cleanup,
+        and finish with ``await super().close(recursive=recursive)``.
+        """
+        if recursive:
+            for agent in getattr(self, '_agents', {}).values():
+                await _maybe_close(agent)
 
     def get_messages(self, prefix='', destination=None) -> Dict[str, List[dict]]:
         """Get OpenAI format messages from all agents recursively, similar to state_dict.
@@ -241,7 +268,7 @@ class StreamingAgentMixin:
             if result:
                 message = result
         self.memory.add(message)
-        response_message = AgentMessage(sender=self.name, content="")
+        response_message = AgentMessage(sender=self.name, content='')
         for response_message in self.forward(*message, **kwargs):
             if not isinstance(response_message, AgentMessage):
                 model_state, response = response_message
@@ -282,7 +309,7 @@ class AsyncStreamingAgentMixin:
             if result:
                 message = result
         self.memory.add(message)
-        response_message = AgentMessage(sender=self.name, content="")
+        response_message = AgentMessage(sender=self.name, content='')
         async for response_message in self.forward(*message, **kwargs):
             if not isinstance(response_message, AgentMessage):
                 model_state, response = response_message

--- a/lagent/agents/fc_agent.py
+++ b/lagent/agents/fc_agent.py
@@ -13,7 +13,7 @@ from tenacity import retry, retry_if_result, stop_after_attempt, wait_fixed
 from lagent.schema import ActionReturn, ActionStatusCode, ActionValidCode, AgentMessage
 from lagent.skills.skills import SkillsLoader
 from lagent.utils import create_object, load_class_from_string, truncate_text
-from .agent import AsyncAgent
+from .agent import AsyncAgent, _maybe_close
 
 logger = logging.getLogger('lagent.agents.fc_agent')
 
@@ -85,9 +85,8 @@ class FunctionCallAgent(AsyncAgent):
 
         final_message = deepcopy(policy_message if policy_message is not None else env_message)
         final_message.sender = self.name
-        final_message.extra_info = dict(final_message.extra_info or {})
         if finish_info:
-            final_message.extra_info['finish_info'] = finish_info
+            final_message.finish_info = finish_info
         return final_message
 
     def _check_finish_condition(
@@ -147,21 +146,15 @@ class FunctionCallAgent(AsyncAgent):
 
     def get_messages(self, prefix='', destination=None) -> List[Dict[str, list]]:
         message_dict = super().get_messages(prefix, destination)
-        segment = {'messages': message_dict['policy_agent.messages'], 'tools': message_dict['policy_agent.tools']}
-        finish_info = None
-        if self.memory is not None:
-            for message in reversed(self.memory.get_memory()):
-                if isinstance(message, AgentMessage) and message.sender == self.name:
-                    finish_info = (message.extra_info or {}).get('finish_info')
-                    break
-        if finish_info:
-            segment['finish_info'] = finish_info
-        return [segment]
+        return [{'messages': message_dict['policy_agent.messages'], 'tools': message_dict['policy_agent.tools']}]
 
 
 class MemoryProvider(Protocol):
     async def get_info(self) -> dict:
-        """Return long-term memory info for EnvAgent's env_info. The content and format are flexible, but should be concise."""
+        """Return long-term memory info for EnvAgent's env_info.
+
+        The content and format are flexible, but should be concise.
+        """
         ...
 
 
@@ -264,3 +257,15 @@ class EnvAgent(AsyncAgent):
         if tool_response.tool_response_truncate_side is None:
             tool_response.tool_response_truncate_side = self.tool_response_truncate_side
         return tool_response
+
+    async def close(self, recursive: bool = True) -> None:
+        seen = set()
+        for action in self.actions.values():
+            action_id = id(action)
+            if action_id in seen:
+                continue
+            seen.add(action_id)
+            await _maybe_close(action)
+        await _maybe_close(self.skills)
+        await _maybe_close(self.long_term_memory)
+        await super().close(recursive=recursive)

--- a/lagent/agents/fc_agent.py
+++ b/lagent/agents/fc_agent.py
@@ -10,12 +10,12 @@ from typing import Any, Dict, List, Literal, Optional, Protocol, Union
 
 from tenacity import retry, retry_if_result, stop_after_attempt, wait_fixed
 
-from lagent.schema import ActionReturn, ActionStatusCode, ActionValidCode, AgentMessage, AgentStatusCode
+from lagent.schema import ActionReturn, ActionStatusCode, ActionValidCode, AgentMessage
 from lagent.skills.skills import SkillsLoader
 from lagent.utils import create_object, load_class_from_string, truncate_text
 from .agent import AsyncAgent
 
-logger = logging.getLogger("lagent.agents.fc_agent")
+logger = logging.getLogger('lagent.agents.fc_agent')
 
 
 class FunctionCallAgent(AsyncAgent):
@@ -25,9 +25,8 @@ class FunctionCallAgent(AsyncAgent):
         env_agent: Union[Dict, AsyncAgent],
         compact_agent: Optional[Dict] = None,
         consolidate_agent: Optional[Dict] = None,
-        finish_condition: callable = lambda m, _: m and not m.tool_calls,
+        finish_condition: callable = lambda m, _: {'reason': 'final_answer'} if m and not m.tool_calls else None,
         max_turn: Optional[int] = None,
-        initialize_input: bool = True,
         name: Optional[str] = None,
         **kwargs,
     ):
@@ -38,39 +37,67 @@ class FunctionCallAgent(AsyncAgent):
         self.consolidate_agent = create_object(consolidate_agent)
         if isinstance(finish_condition, str):
             finish_condition = load_class_from_string(finish_condition)
+        elif isinstance(finish_condition, dict):
+            finish_condition = create_object(finish_condition)
         self.finish_condition = finish_condition
         self.max_turn = max_turn
-        self.initialize_input = initialize_input
 
     async def forward(self, env_message: AgentMessage, **kwargs):
-        policy_message: AgentMessage = None
+        policy_message: Optional[AgentMessage] = None
+        finish_info: Optional[dict] = None
         current_turn = 0
-        if self.initialize_input:
-            env_message = await self.env_agent(env_message, **kwargs)
+        env_message = await self.env_agent(env_message, **kwargs)
 
-        while (self.finish_condition is None or not self.finish_condition(policy_message, env_message)) and (
-            self.max_turn is None or current_turn < self.max_turn
-        ):
+        while True:
+            if self.max_turn is not None and current_turn > self.max_turn:
+                finish_info = {
+                    'reason': 'max_turn',
+                    'details': {'current_turn': current_turn, 'max_turn': self.max_turn},
+                }
+                break
+
             policy_message = await self.policy_agent(env_message, **kwargs)
             if policy_message.finish_reason == 'error':
-                for _ in range(2):  # remove the last two messages
+                details = {'finish_reason': policy_message.finish_reason}
+                error_info = policy_message.extra_info or {}
+                if error_info.get('error_type') is not None:
+                    details['error_type'] = error_info['error_type']
+                if error_info.get('error_text') is not None:
+                    details['error_text'] = truncate_text(str(error_info['error_text']), max_num=512, side='middle')
+                finish_info = {'reason': 'input_length_exceeded', 'details': details}
+                for _ in range(2):  # remove the last env input and input-length error assistant message
                     self.policy_agent.memory.delete(-1)
-                return AgentMessage(
-                    sender=self.name,
-                    content=policy_message.content,
-                    finish_reason=policy_message.finish_reason,
-                )
-            if policy_message.finish_reason == 'abort':
-                return AgentMessage(sender=self.name, content=policy_message.content, finish_reason='abort')
+                break
+
+            finish_info = self._check_finish_condition(policy_message, None)
+            if finish_info is not None:
+                break
 
             # Orchestrator manages memory
             await self._maybe_manage_memory(policy_message, env_message)
 
             env_message = await self.env_agent(policy_message)
             current_turn += 1
-        if policy_message is not None:
-            return AgentMessage(sender=self.name, content=policy_message.content, finish_reason='stop')
-        return AgentMessage(sender=self.name, content="Finished", finish_reason='stop')
+
+            finish_info = self._check_finish_condition(policy_message, env_message)
+            if finish_info is not None:
+                break
+
+        final_message = deepcopy(policy_message if policy_message is not None else env_message)
+        final_message.sender = self.name
+        final_message.extra_info = dict(final_message.extra_info or {})
+        if finish_info:
+            final_message.extra_info['finish_info'] = finish_info
+        return final_message
+
+    def _check_finish_condition(
+        self,
+        policy_message: Optional[AgentMessage],
+        env_message: Optional[AgentMessage],
+    ) -> Optional[dict]:
+        if self.finish_condition is None:
+            return None
+        return self.finish_condition(policy_message, env_message)
 
     async def _maybe_manage_memory(self, policy_message: AgentMessage, env_message: AgentMessage) -> None:
         """Orchestrate compact and consolidate.
@@ -102,9 +129,9 @@ class FunctionCallAgent(AsyncAgent):
             try:
                 await self.consolidate_agent(compact_input)
                 self.consolidate_agent.reset(recursive=True)
-                logger.info("Consolidation completed")
+                logger.info('Consolidation completed')
             except Exception:
-                logger.exception("Consolidation failed, continuing with compact")
+                logger.exception('Consolidation failed, continuing with compact')
         # 2. Compact — inject summary + boundary into env_message
         try:
             summary_msg = await self.compact_agent(compact_input)
@@ -114,13 +141,22 @@ class FunctionCallAgent(AsyncAgent):
                     env_message.env_info = {}
                 env_message.env_info['conversation_summary'] = summary_msg.content
                 env_message.env_info['compact_boundary'] = len(self.policy_agent.memory.memory)
-                logger.info("Compact summary injected (%d chars)", len(summary_msg.content))
+                logger.info('Compact summary injected (%d chars)', len(summary_msg.content))
         except Exception:
-            logger.exception("Compact failed")
+            logger.exception('Compact failed')
 
     def get_messages(self, prefix='', destination=None) -> List[Dict[str, list]]:
         message_dict = super().get_messages(prefix, destination)
-        return [{'messages': message_dict['policy_agent.messages'], 'tools': message_dict['policy_agent.tools']}]
+        segment = {'messages': message_dict['policy_agent.messages'], 'tools': message_dict['policy_agent.tools']}
+        finish_info = None
+        if self.memory is not None:
+            for message in reversed(self.memory.get_memory()):
+                if isinstance(message, AgentMessage) and message.sender == self.name:
+                    finish_info = (message.extra_info or {}).get('finish_info')
+                    break
+        if finish_info:
+            segment['finish_info'] = finish_info
+        return [segment]
 
 
 class MemoryProvider(Protocol):
@@ -181,6 +217,24 @@ class EnvAgent(AsyncAgent):
         tool_responses = await asyncio.gather(
             *[self._retry_mechanism(self.execute_tool)(tool_call) for tool_call in message.tool_calls]
         )
+        for tool_response in tool_responses:
+            if tool_response.valid != ActionValidCode.OPEN or tool_response.state != ActionStatusCode.SUCCESS:
+                continue
+            max_length = tool_response.max_tool_response_length
+            if max_length is None:
+                continue
+            result_parts = []
+            for item in tool_response.result or []:
+                if item['type'] == 'text':
+                    result_parts.append(item['content'])
+                else:
+                    result_parts.append(f"[{item['type']}]({item['content']})")
+            result = '\n'.join(result_parts)
+            if len(result) > max_length:
+                result = truncate_text(
+                    result, max_num=max_length, side=tool_response.tool_response_truncate_side or 'middle'
+                )
+                tool_response.result = [{'type': 'text', 'content': result}]
         content = [asdict(resp) for resp in tool_responses]
         return AgentMessage(sender=self.name, content=content, env_info=await self.get_env_info())
 
@@ -191,11 +245,15 @@ class EnvAgent(AsyncAgent):
             if 'function' in tool_call:
                 tool_call = tool_call['function']
             if tool_call['name'] not in self.actions:
-                return ActionReturn(valid=ActionValidCode.INVALID, errmsg=f'Tool {tool_call["name"]} Not Found')
+                return ActionReturn(
+                    valid=ActionValidCode.INVALID, errmsg=f'FunctionNotFindError: Tool {tool_call["name"]} Not Found'
+                )
             if isinstance(tool_call['arguments'], str):
                 tool_call['arguments'] = json.loads(tool_call['arguments'])
         except Exception as e:
-            return ActionReturn(valid=ActionValidCode.INVALID, errmsg=f'Invalid tool call format: {str(e)}')
+            return ActionReturn(
+                valid=ActionValidCode.INVALID, errmsg=f'JsonLoadError: Invalid tool call format: {str(e)}'
+            )
         action = self.actions[tool_call['name']]
         tool_response: ActionReturn = await action(
             tool_call['arguments'], tool_call['name'].rsplit('.', 1)[-1] if action.is_toolkit else 'run'

--- a/lagent/llms/model.py
+++ b/lagent/llms/model.py
@@ -41,9 +41,9 @@ class AsyncAPIClient(AsyncGPTAPI):
             url.rstrip('/') + '/chat/completions'
             for url in (model['base_url'] if isinstance(model['base_url'], list) else [model['base_url']])
         ]
-        self.api_key = model.get("api_key", "")
-        self.proxy = model.get("proxy")
-        self.model_name = model["model"]
+        self.api_key = model.get('api_key', '')
+        self.proxy = model.get('proxy')
+        self.model_name = model['model']
         self.sample_params = sample_params
         self.max_retry = max_retry
         self.timeout = timeout
@@ -54,11 +54,11 @@ class AsyncAPIClient(AsyncGPTAPI):
     @staticmethod
     def _is_input_length_error_text(text: str) -> bool:
         input_length_markers = [
-            "INPUT_LENGTH_ERROR",
-            "input length",
-            "prompt length",
-            "session out of limit",
-            "SESSION_OUT_OF_LIMIT",
+            'INPUT_LENGTH_ERROR',
+            'input length',
+            'prompt length',
+            'session out of limit',
+            'SESSION_OUT_OF_LIMIT',
         ]
         return any(marker in text for marker in input_length_markers)
 
@@ -70,27 +70,27 @@ class AsyncAPIClient(AsyncGPTAPI):
         msg = str(exc)
         if AsyncAPIClient._is_input_length_error_text(msg):
             return False
-        if msg.startswith("LLM HTTP "):
+        if msg.startswith('LLM HTTP '):
             try:
-                status = int(msg.split("LLM HTTP ", 1)[1].split()[0])
+                status = int(msg.split('LLM HTTP ', 1)[1].split()[0])
             except (IndexError, ValueError):
                 return False
             return status >= 500
 
         retryable_markers = [
-            "LLM stream error",
-            "LLM stream ended without",
-            "LLM finish_reason=error",
-            "Invalid LLM SSE JSON",
-            "Internal error",
-            "Backend error",
+            'LLM stream error',
+            'LLM stream ended without',
+            'LLM finish_reason=error',
+            'Invalid LLM SSE JSON',
+            'Internal error',
+            'Backend error',
             '"code": 500',
             '"code": 503',
             "'code': 500",
             "'code': 503",
-            "TimeoutError",
-            "Connection reset",
-            "Server disconnected",
+            'TimeoutError',
+            'Connection reset',
+            'Server disconnected',
         ]
         return any(marker in msg for marker in retryable_markers)
 
@@ -106,25 +106,25 @@ class AsyncAPIClient(AsyncGPTAPI):
         """
         assert isinstance(messages, list)
 
-        reasoning_effort = self.sample_params.get("reasoning_effort")
+        reasoning_effort = self.sample_params.get('reasoning_effort')
         payload: Dict = dict(
             model=self.model_name,
             messages=messages,
             stream=True,
-            temperature=self.sample_params.get("temperature", 0.7),
-            top_p=self.sample_params.get("top_p", 1.0),
-            max_tokens=self.sample_params.get("max_tokens", 64 * 1024),
+            temperature=self.sample_params.get('temperature', 0.7),
+            top_p=self.sample_params.get('top_p', 1.0),
+            max_tokens=self.sample_params.get('max_tokens', 64 * 1024),
         )
         if tools is not None:
-            payload["tools"] = tools
+            payload['tools'] = tools
         if reasoning_effort is not None:
-            payload["reasoning_effort"] = reasoning_effort
+            payload['reasoning_effort'] = reasoning_effort
         if self.extra_body:
             payload.update(self.extra_body)
         if self.session_id is not None:
-            payload["session_id"] = self.session_id
+            payload['session_id'] = self.session_id
 
-        headers = {"Content-Type": "application/json", "Authorization": f"Bearer {self.api_key}"}
+        headers = {'Content-Type': 'application/json', 'Authorization': f"Bearer {self.api_key}"}
 
         connector = aiohttp.TCPConnector(ssl=False)
         timeout = aiohttp.ClientTimeout(total=self.timeout)
@@ -133,12 +133,12 @@ class AsyncAPIClient(AsyncGPTAPI):
                 url = random.choice(self.base_urls)
                 try:
                     message_data = {
-                        "id": "",
-                        "object": "chat.completion",
-                        "created": 0,
-                        "model": self.model_name,
-                        "choices": [
-                            {"index": 0, "message": {"role": "assistant", "content": ""}, "finish_reason": None}
+                        'id': '',
+                        'object': 'chat.completion',
+                        'created': 0,
+                        'model': self.model_name,
+                        'choices': [
+                            {'index': 0, 'message': {'role': 'assistant', 'content': ''}, 'finish_reason': None}
                         ],
                     }
                     content_parts = []
@@ -157,92 +157,97 @@ class AsyncAPIClient(AsyncGPTAPI):
 
                         async for line in resp.content:
                             if line:
-                                decoded = line.decode("utf-8").strip()
+                                decoded = line.decode('utf-8').strip()
                                 if not decoded:
                                     continue
-                                if decoded.startswith("data: "):
+                                if decoded.startswith('data: '):
                                     data_str = decoded[6:]
-                                    if data_str == "[DONE]":
+                                    if data_str == '[DONE]':
                                         saw_done = True
                                         break
                                     try:
                                         data = json.loads(data_str)
                                         last_event = data
                                         if (
-                                            data.get("error") is not None
-                                            or data.get("type") == "error"
-                                            or data.get("object") == "error"
+                                            data.get('error') is not None
+                                            or data.get('type') == 'error'
+                                            or data.get('object') == 'error'
                                         ):
                                             raise RuntimeError(
                                                 f"LLM stream error from {url}: {json.dumps(data, ensure_ascii=False)}"
                                             )
-                                        if "id" in data and not message_data["id"]:
-                                            message_data["id"] = data["id"]
-                                        if "created" in data and not message_data["created"]:
-                                            message_data["created"] = data["created"]
-                                        if "model" in data:
-                                            message_data["model"] = data["model"]
+                                        if 'id' in data and not message_data['id']:
+                                            message_data['id'] = data['id']
+                                        if 'created' in data and not message_data['created']:
+                                            message_data['created'] = data['created']
+                                        if 'model' in data:
+                                            message_data['model'] = data['model']
 
-                                        choices = data.get("choices", [])
+                                        choices = data.get('choices', [])
                                         if choices:
                                             saw_choice = True
 
                                         for choice in choices:
-                                            delta = choice.get("delta", {})
+                                            delta = choice.get('delta', {})
 
-                                            if "content" in delta and delta["content"]:
-                                                content_parts.append(delta["content"])
+                                            if 'content' in delta and delta['content']:
+                                                content_parts.append(delta['content'])
 
-                                            if "reasoning_content" in delta and delta["reasoning_content"]:
-                                                reasoning_content_parts.append(delta["reasoning_content"])
+                                            if 'reasoning_content' in delta and delta['reasoning_content']:
+                                                reasoning_content_parts.append(delta['reasoning_content'])
 
-                                            for tc_delta in delta.get("tool_calls") or []:
-                                                idx = tc_delta.get("index", 0)
+                                            for tc_delta in delta.get('tool_calls') or []:
+                                                idx = tc_delta.get('index', 0)
                                                 if idx not in tool_calls_map:
                                                     tool_calls_map[idx] = {
-                                                        "id": tc_delta.get("id", ""),
-                                                        "type": tc_delta.get("type", "function"),
-                                                        "function": {"name": "", "arguments": ""},
+                                                        'id': tc_delta.get('id', ''),
+                                                        'type': tc_delta.get('type', 'function'),
+                                                        'function': {'name': '', 'arguments': ''},
                                                     }
                                                 tc = tool_calls_map[idx]
-                                                fn = tc_delta.get("function", {})
-                                                if fn.get("name"):
-                                                    tc["function"]["name"] += fn["name"]
-                                                if fn.get("arguments"):
-                                                    tc["function"]["arguments"] += fn["arguments"]
-                                                if tc_delta.get("id"):
-                                                    tc["id"] = tc_delta["id"]
+                                                fn = tc_delta.get('function', {})
+                                                if fn.get('name'):
+                                                    tc['function']['name'] += fn['name']
+                                                if fn.get('arguments'):
+                                                    tc['function']['arguments'] += fn['arguments']
+                                                if tc_delta.get('id'):
+                                                    tc['id'] = tc_delta['id']
 
-                                            fc_delta = delta.get("function_call")
+                                            fc_delta = delta.get('function_call')
                                             if fc_delta:
                                                 if function_call_data is None:
-                                                    function_call_data = {"name": "", "arguments": ""}
-                                                if fc_delta.get("name"):
-                                                    function_call_data["name"] += fc_delta["name"]
-                                                if fc_delta.get("arguments"):
-                                                    function_call_data["arguments"] += fc_delta["arguments"]
+                                                    function_call_data = {'name': '', 'arguments': ''}
+                                                if fc_delta.get('name'):
+                                                    function_call_data['name'] += fc_delta['name']
+                                                if fc_delta.get('arguments'):
+                                                    function_call_data['arguments'] += fc_delta['arguments']
 
-                                            if "finish_reason" in choice and choice["finish_reason"]:
-                                                message_data["choices"][0]["finish_reason"] = choice["finish_reason"]
-                                                if choice["finish_reason"] == "error":
-                                                    error_text = " ".join(
+                                            if 'finish_reason' in choice and choice['finish_reason']:
+                                                message_data['choices'][0]['finish_reason'] = choice['finish_reason']
+                                                if choice['finish_reason'] == 'error':
+                                                    error_text = ' '.join(
                                                         part
                                                         for part in [
-                                                            "".join(content_parts),
+                                                            ''.join(content_parts),
                                                             json.dumps(data, ensure_ascii=False),
                                                         ]
                                                         if part
                                                     )
                                                     if self._is_input_length_error_text(error_text):
-                                                        message_data["choices"][0]["message"].update(delta)
+                                                        message = message_data['choices'][0]['message']
+                                                        message.update(delta)
+                                                        extra_info = dict(message.get('extra_info') or {})
+                                                        extra_info.setdefault('error_type', 'input_length_error')
+                                                        extra_info.setdefault('error_text', error_text)
+                                                        message['extra_info'] = extra_info
                                                         return message_data
                                                     raise RuntimeError(
                                                         f"LLM finish_reason=error from {url}: "
                                                         f"{json.dumps(data, ensure_ascii=False)}"
                                                     )
 
-                                        if "usage" in data and data["usage"]:
-                                            usage = data["usage"]
+                                        if 'usage' in data and data['usage']:
+                                            usage = data['usage']
                                     except json.JSONDecodeError as exc:
                                         raise RuntimeError(f"Invalid LLM SSE JSON from {url}: {data_str}") from exc
 
@@ -256,41 +261,41 @@ class AsyncAPIClient(AsyncGPTAPI):
                             f"LLM stream ended without [DONE] from {url}: "
                             f"{json.dumps(last_event, ensure_ascii=False) if last_event is not None else None}"
                         )
-                    if not message_data["choices"][0].get("finish_reason"):
+                    if not message_data['choices'][0].get('finish_reason'):
                         raise RuntimeError(
                             f"LLM stream ended without terminal finish_reason from {url}: "
                             f"{json.dumps(last_event, ensure_ascii=False) if last_event is not None else None}"
                         )
 
-                    msg = message_data["choices"][0]["message"]
-                    msg["content"] = "".join(content_parts)
+                    msg = message_data['choices'][0]['message']
+                    msg['content'] = ''.join(content_parts)
                     if reasoning_content_parts:
-                        msg["reasoning_content"] = "".join(reasoning_content_parts)
+                        msg['reasoning_content'] = ''.join(reasoning_content_parts)
 
                     if tool_calls_map:
                         tool_calls = []
                         for idx in sorted(tool_calls_map.keys()):
                             tc = tool_calls_map[idx]
-                            args = tc["function"].get("arguments")
+                            args = tc['function'].get('arguments')
                             if isinstance(args, str):
                                 try:
-                                    tc["function"]["arguments"] = json.loads(args)
+                                    tc['function']['arguments'] = json.loads(args)
                                 except json.JSONDecodeError:
                                     pass
                             tool_calls.append(tc)
-                        msg["tool_calls"] = tool_calls
+                        msg['tool_calls'] = tool_calls
 
                     if function_call_data:
-                        args = function_call_data.get("arguments")
+                        args = function_call_data.get('arguments')
                         if isinstance(args, str):
                             try:
-                                function_call_data["arguments"] = json.loads(args)
+                                function_call_data['arguments'] = json.loads(args)
                             except json.JSONDecodeError:
                                 pass
-                        msg["function_call"] = function_call_data
+                        msg['function_call'] = function_call_data
 
                     if usage:
-                        message_data["usage"] = usage
+                        message_data['usage'] = usage
 
                     return message_data
 
@@ -304,12 +309,12 @@ class AsyncAPIClient(AsyncGPTAPI):
                     should_retry = self._is_retryable_error(e) or any(
                         val in str(e)
                         for val in [
-                            "用户额度不足",
-                            "剩余额度",
-                            "litellm.BadRequestError",
-                            "litellm.APIError: APIError",
-                            "Failed to parse fc related info to json format!",
-                            "Error code",
+                            '用户额度不足',
+                            '剩余额度',
+                            'litellm.BadRequestError',
+                            'litellm.APIError: APIError',
+                            'Failed to parse fc related info to json format!',
+                            'Error code',
                         ]
                     )
                     if should_retry:
@@ -390,9 +395,9 @@ if __name__ == '__main__':
     # extra_body = {}
 
     extra_body = {'enable_thinking': True, 'spaces_between_special_tokens': False}
-    model_name = "/mnt/shared-storage-user/llmit1/user/liujiangning/exp/s2_preview/agent_rl/s2-preview-thinker_sft_0228b_rl0312rc1_fix_klmismatch/20260331212858/hf-15"
-    api_base = "http://10.102.252.171:23333/v1"
-    api_key = "sk-admin"
+    model_name = '/mnt/shared-storage-user/llmit1/user/liujiangning/exp/s2_preview/agent_rl/s2-preview-thinker_sft_0228b_rl0312rc1_fix_klmismatch/20260331212858/hf-15'
+    api_base = 'http://10.102.252.171:23333/v1'
+    api_key = 'sk-admin'
     proxy = None
 
     async def main():
@@ -407,6 +412,6 @@ if __name__ == '__main__':
             extra_body=extra_body,
         )
         response = await model.chat(messages, tools=tools)
-        print("Response:", response)
+        print('Response:', response)
 
     asyncio.run(main())

--- a/lagent/schema.py
+++ b/lagent/schema.py
@@ -18,13 +18,41 @@ def dataclass2dict(data):
     return asdict(data, dict_factory=enum_dict_factory)
 
 
+class _StatusCodeMixin:
+    """Mixin for IntEnum status codes. Adds ``from_any`` to recover the enum
+    member after JSON/Ray serialization round-trips (where IntEnum may degrade
+    to int, member-name string, or stringified int). Returns ``None`` when no
+    member matches, so callers can keep the comparison silent.
+    """
+
+    @classmethod
+    def from_any(cls, value):
+        if isinstance(value, cls):
+            return value
+        if isinstance(value, bool):
+            return None
+        if isinstance(value, int):
+            try:
+                return cls(value)
+            except ValueError:
+                return None
+        if isinstance(value, str):
+            if value in cls.__members__:
+                return cls[value]
+            try:
+                return cls(int(value))
+            except (ValueError, TypeError):
+                return None
+        return None
+
+
 @dataclass
 class FunctionCall:
     name: str
     parameters: Union[Dict, str]
 
 
-class ActionStatusCode(IntEnum):
+class ActionStatusCode(_StatusCodeMixin, IntEnum):
     ING = 1
     SUCCESS = 0
     HTTP_ERROR = -1000  # http error
@@ -32,7 +60,7 @@ class ActionStatusCode(IntEnum):
     API_ERROR = -1002  # unknown error
 
 
-class ActionValidCode(IntEnum):
+class ActionValidCode(_StatusCodeMixin, IntEnum):
     FINISH = 1
     OPEN = 0
     CLOSED = -1
@@ -73,7 +101,7 @@ class ActionReturn:
 
 
 # need to integrate int, so asdict can convert AgentStatusCode to int
-class ModelStatusCode(IntEnum):
+class ModelStatusCode(_StatusCodeMixin, IntEnum):
     END = 0  # end of streaming
     STREAM_ING = 1  # response is in streaming
     SERVER_ERR = -1  # triton server's error
@@ -83,7 +111,7 @@ class ModelStatusCode(IntEnum):
     SESSION_READY = 2  # session is ready for inference
 
 
-class AgentStatusCode(IntEnum):
+class AgentStatusCode(_StatusCodeMixin, IntEnum):
     END = 0  # end of streaming
     STREAM_ING = 1  # response is in streaming
     SERVER_ERR = -1  # triton server's error
@@ -109,6 +137,7 @@ class AgentMessage(BaseModel):
     extra_info: dict = Field(default_factory=dict)
     stream_state: Union[ModelStatusCode, AgentStatusCode] = AgentStatusCode.END
     finish_reason: Optional[str] = None
+    finish_info: Optional[dict] = None
     uid: Union[int, str] = Field(default_factory=lambda: uuid4().hex, repr=False)
     env_info: Optional[Dict[str, Any]] = None
 
@@ -130,8 +159,6 @@ class AgentMessage(BaseModel):
         msg = choice.get('message', {})
         finish_reason = choice.get('finish_reason')
         extra_info = dict(msg.get('extra_info') or {})
-        if finish_reason is not None:
-            extra_info.setdefault('finish_reason', finish_reason)
 
         meta_info = dict(extra_info.get('meta_info') or {})
         for key in ('id', 'model', 'created', 'usage'):

--- a/lagent/schema.py
+++ b/lagent/schema.py
@@ -121,7 +121,7 @@ class AgentMessage(BaseModel):
             self.role = self.sender
 
     @classmethod
-    def from_model_response(cls, response: Union[ChatCompletion, dict], sender: str) -> "AgentMessage":
+    def from_model_response(cls, response: Union[ChatCompletion, dict], sender: str) -> 'AgentMessage':
         """Convert model response (ChatCompletion object or model_dump dict) to AgentMessage."""
         if not isinstance(response, dict):
             response = response.model_dump()
@@ -129,12 +129,25 @@ class AgentMessage(BaseModel):
         choice = response['choices'][0]
         msg = choice.get('message', {})
         finish_reason = choice.get('finish_reason')
+        extra_info = dict(msg.get('extra_info') or {})
+        if finish_reason is not None:
+            extra_info.setdefault('finish_reason', finish_reason)
+
+        meta_info = dict(extra_info.get('meta_info') or {})
+        for key in ('id', 'model', 'created', 'usage'):
+            if response.get(key) is not None:
+                meta_info[key] = response[key]
+        if choice.get('index') is not None:
+            meta_info['choice_index'] = choice['index']
+        if meta_info:
+            extra_info['meta_info'] = meta_info
+
         return cls(
             sender=sender,
-            content=msg.get('content') or "",
+            content=msg.get('content') or '',
             reasoning_content=msg.get('reasoning_content'),
             tool_calls=msg.get('tool_calls'),
-            extra_info=msg.get('extra_info') or {},
+            extra_info=extra_info,
             stream_state=choice.get('stream_state', AgentStatusCode.END),
             finish_reason=finish_reason,
         )
@@ -161,8 +174,12 @@ class AgentMessage(BaseModel):
             return res
 
         msg = {'role': final_role, 'content': self.content}
-        if final_role != 'assistant':
-            msg['extra_info'] = self.extra_info
+        extra_info = self.extra_info
+        if self.finish_reason is not None:
+            extra_info = dict(extra_info)
+            extra_info.setdefault('finish_reason', self.finish_reason)
+        if final_role != 'assistant' or extra_info:
+            msg['extra_info'] = extra_info
         if self.reasoning_content is not None:
             msg['reasoning_content'] = self.reasoning_content
         if self.tool_calls is not None:

--- a/lagent/utils/rate_limiter.py
+++ b/lagent/utils/rate_limiter.py
@@ -1,0 +1,119 @@
+"""Async rate limiters used across lagent (mcp client, custom actions, RL recipes).
+
+Single source of truth — both the in-process limiter class and the
+process-shared registry helper live here so that callers don't fork their own
+implementations.
+"""
+
+from __future__ import annotations
+import asyncio
+import threading
+import time
+from collections import deque
+from typing import Deque
+
+
+class FairAsyncTokenBucket:
+    """FIFO async token bucket.
+
+    A single drainer task wakes waiters in arrival order, so high-concurrency
+    callers don't form a thundering herd around `asyncio.sleep`.
+    """
+
+    def __init__(self, rate_limit: float, capacity: float | None = None):
+        """rate_limit: tokens per second; capacity: burst size (defaults to rate_limit)."""
+        self.rate_limit = float(rate_limit)
+        self.capacity = float(capacity) if capacity is not None else float(rate_limit)
+        self.tokens = self.capacity
+        self.last_update = time.monotonic()
+        self._lock = asyncio.Lock()
+        self._waiters: Deque[asyncio.Future] = deque()
+        self._drainer_running = False
+
+    def _refill_unlocked(self) -> None:
+        now = time.monotonic()
+        elapsed = now - self.last_update
+        if elapsed <= 0:
+            return
+        self.tokens = min(self.capacity, self.tokens + elapsed * self.rate_limit)
+        self.last_update = now
+
+    async def _drain_waiters(self) -> None:
+        try:
+            while True:
+                fut_to_wake: asyncio.Future | None = None
+                sleep_time: float | None = None
+
+                async with self._lock:
+                    self._refill_unlocked()
+
+                    if not self._waiters:
+                        self._drainer_running = False
+                        return
+
+                    if self.tokens >= 1:
+                        self.tokens -= 1
+                        fut_to_wake = self._waiters.popleft()
+                        sleep_time = 0.0
+                    else:
+                        missing = 1.0 - self.tokens
+                        sleep_time = max(0.0, missing / self.rate_limit)
+
+                if fut_to_wake is not None and not fut_to_wake.done():
+                    fut_to_wake.set_result(None)
+
+                if sleep_time == 0.0:
+                    continue
+
+                await asyncio.sleep(sleep_time)
+        finally:
+            async with self._lock:
+                self._drainer_running = False
+
+    async def acquire(self) -> None:
+        loop = asyncio.get_running_loop()
+
+        async with self._lock:
+            self._refill_unlocked()
+
+            if self.tokens >= 1 and not self._waiters:
+                self.tokens -= 1
+                return
+
+            fut = loop.create_future()
+            self._waiters.append(fut)
+
+            if not self._drainer_running:
+                self._drainer_running = True
+                asyncio.create_task(self._drain_waiters())
+
+        await fut
+
+
+_SHARED_LIMITERS: dict[str, FairAsyncTokenBucket] = {}
+_SHARED_LIMITERS_LOCK = threading.Lock()
+
+
+def get_shared_async_token_bucket(
+    key: str,
+    rate_limit: float,
+    capacity: float | None = None,
+) -> FairAsyncTokenBucket:
+    """Return a process-shared FairAsyncTokenBucket registered under `key`.
+
+    First call for a key wins the rate/capacity; subsequent calls reuse the
+    existing limiter (their rate/capacity arguments are ignored). Limiters live
+    for the lifetime of the process and are scoped per-process — Ray actors are
+    separate processes and therefore each maintain their own registry.
+    """
+    if not key:
+        raise ValueError('rate limiter key must be non-empty')
+    with _SHARED_LIMITERS_LOCK:
+        limiter = _SHARED_LIMITERS.get(key)
+        if limiter is None:
+            limiter = FairAsyncTokenBucket(rate_limit=rate_limit, capacity=capacity)
+            _SHARED_LIMITERS[key] = limiter
+        return limiter
+
+
+__all__ = ['FairAsyncTokenBucket', 'get_shared_async_token_bucket']


### PR DESCRIPTION
- AgentMessage gains a first-class finish_info field; fc_agent writes it
  top-level and get_messages no longer reverse-scans memory for it.
- Add Agent.close() default that recursively closes sub-agents in _agents;
  EnvAgent overrides to also close its actions / skills / long_term_memory
  before delegating to super().close().
- Hoist FairAsyncTokenBucket + the process-shared registry to
  lagent.utils.rate_limiter; mcp_client drops four local bucket classes
  and routes shared keys through the new helper.
- mcp_client._log_action_failure unwraps ExceptionGroup / __cause__ so the
  actual root causes (httpx / anyio sub-exceptions) show up in logs.
- IntEnum status codes (ActionStatusCode, ActionValidCode, ModelStatusCode,
  AgentStatusCode) gain a from_any() classmethod via _StatusCodeMixin so
  consumers can recover the enum after JSON / Ray serialization round-trips
  without ad-hoc str/int fallbacks.