### PR TITLE
Normalize OpenClaw replayed tool call ids

### DIFF
--- a/lagent/adapters/proxy.py
+++ b/lagent/adapters/proxy.py
@@ -31,6 +31,7 @@ Usage::
 import copy
 import json
 import os
+import re
 import uuid
 from collections import defaultdict
 from typing import Any, Dict, List, Optional
@@ -61,6 +62,7 @@ def _is_lmdeploy_input_length_error(response_data: dict[str, Any]) -> bool:
 _NON_TOKENIZED_KEYS = ('cache_control',)
 _TOKENIZED_MSG_KEYS = ('tool_call_id', 'name', 'reasoning_content', 'function_call', 'refusal')
 _OPENAI_REASONING_DELTA_KEYS = ('reasoning_content', 'reasoning', 'thinking')
+_OPENCLAW_TOOL_CALL_ID_RE = re.compile(r'^call_?([0-9a-fA-F]{8,})$')
 
 
 def _extract_openai_reasoning_delta(delta: dict[str, Any]) -> Optional[str]:
@@ -106,6 +108,18 @@ def _canonical_content(content: Any) -> Any:
     return json.dumps(content, sort_keys=True, ensure_ascii=False)
 
 
+def _canonical_tool_call_id(value: Any) -> Any:
+    if not isinstance(value, str):
+        return value
+    # OpenClaw currently replays history with the underscore in OpenAI-style
+    # tool call ids stripped (`call_<hex>` -> `call<hex>`). Normalize only that
+    # narrow generated-id shape for prefix matching; do not drop the id.
+    match = _OPENCLAW_TOOL_CALL_ID_RE.fullmatch(value)
+    if match:
+        return f"call_{match.group(1).lower()}"
+    return value
+
+
 def _canonical_msg(msg: Any) -> tuple:
     """Project a message onto the fields the model actually conditions on.
 
@@ -126,11 +140,19 @@ def _canonical_msg(msg: Any) -> tuple:
             if isinstance(args, (dict, list)):
                 args = json.dumps(args, sort_keys=True, ensure_ascii=False)
             # Keep the id: it is serialized into the prompt the model conditions on.
-            norm.append((tc.get('id') if isinstance(tc, dict) else None, fn.get('name'), args))
+            norm.append(
+                (
+                    _canonical_tool_call_id(tc.get('id')) if isinstance(tc, dict) else None,
+                    fn.get('name'),
+                    args,
+                )
+            )
         key.append(('tool_calls', tuple(norm)))
     for field in _TOKENIZED_MSG_KEYS:
         val = msg.get(field)
         if val:
+            if field == 'tool_call_id':
+                val = _canonical_tool_call_id(val)
             key.append((field, val if isinstance(val, str) else json.dumps(val, sort_keys=True, ensure_ascii=False)))
     return tuple(key)
 

--- a/tests/test_adapters/test_session_client.py
+++ b/tests/test_adapters/test_session_client.py
@@ -9,6 +9,100 @@ import pytest
 from lagent.adapters.proxy import SessionClient
 
 
+def test_get_messages_normalizes_openclaw_tool_call_id_underscore_loss():
+    proxy = SessionClient(
+        real_api_key="EMPTY",
+        real_base_url="http://example.test/v1",
+        session_id="openclaw_id_replay",
+    )
+    short = {
+        "messages": [
+            {"role": "user", "content": "write files"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_a45f453d817e4c0cbc5ec29d",
+                        "type": "function",
+                        "function": {"name": "bash", "arguments": {"cmd": "pwd"}},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_a45f453d817e4c0cbc5ec29d", "content": "/app"},
+            {"role": "assistant", "content": "done"},
+        ],
+        "tools": None,
+    }
+    long = {
+        "messages": [
+            {"role": "user", "content": "write files"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "calla45f453d817e4c0cbc5ec29d",
+                        "type": "function",
+                        "function": {"name": "bash", "arguments": {"cmd": "pwd"}},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "calla45f453d817e4c0cbc5ec29d", "content": "/app"},
+            {"role": "assistant", "content": "done"},
+            {"role": "user", "content": "next"},
+        ],
+        "tools": None,
+    }
+    proxy._records[proxy.session_id] = [short, long]
+
+    assert proxy.get_messages() == [long]
+
+
+def test_get_messages_keeps_distinct_tool_call_ids_distinct():
+    proxy = SessionClient(
+        real_api_key="EMPTY",
+        real_base_url="http://example.test/v1",
+        session_id="distinct_tool_ids",
+    )
+    first = {
+        "messages": [
+            {"role": "user", "content": "write files"},
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "call_a45f453d817e4c0cbc5ec29d",
+                        "type": "function",
+                        "function": {"name": "bash", "arguments": {"cmd": "pwd"}},
+                    }
+                ],
+            },
+        ],
+        "tools": None,
+    }
+    second = {
+        "messages": [
+            {"role": "user", "content": "write files"},
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "call_b45f453d817e4c0cbc5ec29d",
+                        "type": "function",
+                        "function": {"name": "bash", "arguments": {"cmd": "pwd"}},
+                    }
+                ],
+            },
+            {"role": "user", "content": "next"},
+        ],
+        "tools": None,
+    }
+    proxy._records[proxy.session_id] = [first, second]
+
+    assert proxy.get_messages() == [first, second]
+
+
 @pytest.mark.asyncio
 async def test_session_client_openai():
     # 1. Start the proxy


### PR DESCRIPTION
## Summary

Normalize OpenClaw-replayed tool call ids during `get_messages()` prefix matching.

## Changes

- Canonicalize OpenAI-style tool call ids where OpenClaw history replay drops the underscore, e.g. `call_<hex>` vs `call<hex>`.
- Keep tool call ids in the canonical key instead of dropping them.
- Add tests for the OpenClaw replay case and for preserving distinct tool call ids.