### PR TITLE
Detect OpenAI stream format beyond first event

### DIFF
--- a/lagent/adapters/proxy.py
+++ b/lagent/adapters/proxy.py
@@ -601,13 +601,19 @@ class SessionClient:
         if not events:
             return None
 
-        # Detect format: Responses API events start with "response.";
-        # OpenAI ChatCompletion has "choices"; Anthropic uses message_start / content_block_*
-        first = events[0]
-        evt_type = first.get('type', '')
-        if evt_type.startswith('response.') or first.get('object') == 'response':
+        # Detect format across the whole stream. Some OpenAI-compatible
+        # clients/providers emit an initial metadata event before the first
+        # chunk with ``choices``; looking only at events[0] would misclassify
+        # those streams as Anthropic and drop the trace.
+        if any(
+            (event.get('type', '').startswith('response.') or event.get('object') == 'response')
+            for event in events
+        ):
             return SessionClient._parse_responses_stream(events)
-        if 'choices' in first or first.get('object') == 'chat.completion.chunk':
+        if any(
+            ('choices' in event or event.get('object') == 'chat.completion.chunk')
+            for event in events
+        ):
             return SessionClient._parse_openai_stream(events, saw_done=saw_done)
         return SessionClient._parse_anthropic_stream(events)
 

--- a/tests/test_adapters/test_session_client.py
+++ b/tests/test_adapters/test_session_client.py
@@ -9,6 +9,29 @@ import pytest
 from lagent.adapters.proxy import SessionClient
 
 
+def test_parse_openai_stream_after_initial_metadata_event():
+    chunks = [
+        {"id": "meta-only", "model": "test-model"},
+        {
+            "id": "chatcmpl-test",
+            "object": "chat.completion.chunk",
+            "choices": [{"delta": {"role": "assistant", "content": "ok"}, "finish_reason": None}],
+        },
+        {
+            "id": "chatcmpl-test",
+            "object": "chat.completion.chunk",
+            "choices": [{"delta": {}, "finish_reason": "stop"}],
+        },
+    ]
+    raw = b"".join(f"data: {json.dumps(chunk)}\n\n".encode() for chunk in chunks) + b"data: [DONE]\n\n"
+
+    parsed = SessionClient._parse_stream_response(raw)
+
+    assert parsed is not None
+    assert parsed["choices"][0]["message"]["content"] == "ok"
+    assert parsed["choices"][0]["finish_reason"] == "stop"
+
+
 @pytest.mark.asyncio
 async def test_session_client_openai():
     # 1. Start the proxy


### PR DESCRIPTION
## Summary

Make `SessionClient` stream parsing detect OpenAI-compatible chunks beyond the first SSE event.

## Changes

- Detect stream format by scanning all SSE events instead of only `events[0]`.
- Avoid misclassifying OpenAI-compatible streams as Anthropic when the first event is metadata.
- Add a regression test for a metadata-first OpenAI chat completion stream.