### PR TITLE
feat(llms): add OrcaRouter named provider

### DIFF
--- a/docs/en/get_started/quickstart.md
+++ b/docs/en/get_started/quickstart.md
@@ -483,3 +483,35 @@ bot_msg = visualizer(user_msg)
 print(bot_msg.content)
 json.dump(visualizer.state_dict(), open('visualizer.json', 'w'), ensure_ascii=False, indent=4)
 ````
+
+### Using OrcaRouter
+
+[OrcaRouter](https://www.orcarouter.ai) is a gateway that exposes open-weight
+models from many vendors through a single OpenAI-compatible endpoint. Lagent
+provides named wrappers (`OrcaRouterAPI` / `AsyncOrcaRouterAPI`) that mirror the
+OpenAI wrappers with OrcaRouter defaults.
+
+Set the API key in the environment (keys start with `sk-orca-`):
+
+```bash
+export ORCAROUTER_API_KEY=sk-orca-your-key-here
+```
+
+Then instantiate the wrapper exactly like `GPTAPI`:
+
+```python
+from lagent.llms import OrcaRouterAPI, AsyncOrcaRouterAPI
+
+# Synchronous usage
+llm = OrcaRouterAPI(model_type='orcarouter/auto', retry=5, max_new_tokens=2048)
+
+# Asynchronous usage
+llm = AsyncOrcaRouterAPI(model_type='orcarouter/auto', retry=5, max_new_tokens=2048)
+```
+
+`orcarouter/auto` routes to a suitable open-weight model on the gateway. You can
+also use vendor-qualified model names exposed by the gateway, e.g.
+`deepseek/deepseek-v4-pro` or `openai/gpt-4o-mini`. The wrappers accept any
+model name containing a `/` and forward it verbatim, so you can also pass
+gateway aliases such as `orcarouter/fusion` or `orcarouter/free`.
+

--- a/lagent/llms/__init__.py
+++ b/lagent/llms/__init__.py
@@ -12,6 +12,7 @@ from .lmdeploy_wrapper import (
 )
 from .meta_template import INTERNLM2_META
 from .openai import GPTAPI, AsyncGPTAPI
+from .orcarouter import AsyncOrcaRouterAPI, OrcaRouterAPI
 from .sensenova import SensenovaAPI
 from .vllm_wrapper import AsyncVllmModel, VllmModel
 
@@ -22,6 +23,8 @@ __all__ = [
     'BaseAPILLM',
     'AsyncGPTAPI',
     'GPTAPI',
+    'AsyncOrcaRouterAPI',
+    'OrcaRouterAPI',
     'LMDeployClient',
     'AsyncLMDeployClient',
     'LMDeployPipeline',

--- a/lagent/llms/orcarouter.py
+++ b/lagent/llms/orcarouter.py
@@ -1,0 +1,179 @@
+"""Model wrappers around [OrcaRouter](https://www.orcarouter.ai).
+
+OrcaRouter is a gateway that fronts open-weight models from many vendors
+through a single OpenAI-compatible endpoint. These wrappers mirror the
+``GPTAPI`` / ``AsyncGPTAPI`` wrappers with OrcaRouter defaults so that
+Lagent agents can route to the gateway as a named provider.
+"""
+
+import os
+import warnings
+from typing import Dict, List, Optional, Union
+
+from .openai import AsyncGPTAPI, GPTAPI
+
+ORCAROUTER_API_BASE = 'https://api.orcarouter.ai/v1/chat/completions'
+ORCAROUTER_API_KEY_ENV = 'ORCAROUTER_API_KEY'
+ORCAROUTER_DEFAULT_MODEL = 'orcarouter/auto'
+
+_DEFAULT_META_TEMPLATE = [
+    dict(role='system', api_role='system'),
+    dict(role='user', api_role='user'),
+    dict(role='assistant', api_role='assistant'),
+    dict(role='environment', api_role='system'),
+]
+
+
+def _gateway_request_data(model_type, messages, gen_params, json_mode=False):
+    """Build the request payload for gateway models.
+
+    OrcaRouter is a multi-vendor gateway: accept gateway aliases
+    (``orcarouter/*``) as well as vendor-qualified model names
+    (``vendor/model``) by routing them through the generic Chat Completions
+    path. Return ``None`` so the caller can fall back to the OpenAI wrapper's
+    validation for any other model.
+    """
+    if not (model_type.lower().startswith('orcarouter') or '/' in model_type):
+        return None
+
+    gen_params = gen_params.copy()
+    max_tokens = min(gen_params.pop('max_new_tokens'), 4096)
+    if max_tokens <= 0:
+        return '', ''
+
+    header = {
+        'content-type': 'application/json',
+    }
+
+    gen_params['max_tokens'] = max_tokens
+    if 'stop_words' in gen_params:
+        gen_params['stop'] = gen_params.pop('stop_words')
+    if 'repetition_penalty' in gen_params:
+        gen_params['frequency_penalty'] = gen_params.pop('repetition_penalty')
+    if 'top_k' in gen_params:
+        warnings.warn('`top_k` parameter is deprecated in OpenAI APIs.', DeprecationWarning)
+        gen_params.pop('top_k')
+    gen_params.pop('skip_special_tokens', None)
+    gen_params.pop('session_id', None)
+
+    data = {'model': model_type, 'messages': messages, 'n': 1, **gen_params}
+    if json_mode:
+        data['response_format'] = {'type': 'json_object'}
+    return header, data
+
+
+class OrcaRouterAPI(GPTAPI):
+    """Model wrapper around OrcaRouter's OpenAI-compatible gateway.
+
+    Args:
+        model_type (str): The model to use. Defaults to 'orcarouter/auto',
+            which routes to a suitable open-weight model on the gateway.
+        retry (int): Number of retries if the API call fails. Defaults to 2.
+        key (str or List[str]): OrcaRouter key(s). In particular, when it
+            is set to "ENV", the key will be fetched from the environment
+            variable $ORCAROUTER_API_KEY (keys start with ``sk-orca-``).
+            If it's a list, the keys will be used in round-robin manner.
+            Defaults to 'ENV'.
+        org (str or List[str], optional): OpenAI organization(s), passed
+            through for compatibility. Defaults to None.
+        meta_template (Dict, optional): The model's meta prompt template.
+        api_base (str): The base url of OrcaRouter's OpenAI-compatible API.
+            Defaults to 'https://api.orcarouter.ai/v1/chat/completions'.
+        gen_params: Default generation configuration which could be overridden
+            on the fly of generation.
+    """
+
+    is_api: bool = True
+
+    def __init__(
+        self,
+        model_type: str = ORCAROUTER_DEFAULT_MODEL,
+        retry: int = 2,
+        json_mode: bool = False,
+        key: Union[str, List[str]] = 'ENV',
+        org: Optional[Union[str, List[str]]] = None,
+        meta_template: Optional[Dict] = _DEFAULT_META_TEMPLATE,
+        api_base: str = ORCAROUTER_API_BASE,
+        proxies: Optional[Dict] = None,
+        **gen_params,
+    ):
+        super().__init__(
+            model_type=model_type,
+            retry=retry,
+            json_mode=json_mode,
+            key=key,
+            org=org,
+            meta_template=meta_template,
+            api_base=api_base,
+            proxies=proxies,
+            **gen_params,
+        )
+        # Read OrcaRouter keys from the dedicated env var instead of
+        # $OPENAI_API_KEY.
+        if isinstance(key, str):
+            self.keys = [os.getenv(ORCAROUTER_API_KEY_ENV) if key == 'ENV' else key]
+        else:
+            self.keys = key
+
+    def generate_request_data(self, model_type, messages, gen_params, json_mode=False):
+        result = _gateway_request_data(model_type, messages, gen_params, json_mode)
+        if result is not None:
+            return result
+        return super().generate_request_data(model_type, messages, gen_params, json_mode)
+
+
+class AsyncOrcaRouterAPI(AsyncGPTAPI):
+    """Asynchronous variant of :class:`OrcaRouterAPI`.
+
+    Args:
+        model_type (str): The model to use. Defaults to 'orcarouter/auto'.
+        retry (int): Number of retries if the API call fails. Defaults to 2.
+        key (str or List[str]): OrcaRouter key(s). When set to "ENV", the key
+            is fetched from the environment variable $ORCAROUTER_API_KEY.
+            Defaults to 'ENV'.
+        org (str or List[str], optional): OpenAI organization(s), passed
+            through for compatibility. Defaults to None.
+        meta_template (Dict, optional): The model's meta prompt template.
+        api_base (str): The base url of OrcaRouter's OpenAI-compatible API.
+            Defaults to 'https://api.orcarouter.ai/v1/chat/completions'.
+        gen_params: Default generation configuration which could be overridden
+            on the fly of generation.
+    """
+
+    is_api: bool = True
+
+    def __init__(
+        self,
+        model_type: str = ORCAROUTER_DEFAULT_MODEL,
+        retry: int = 2,
+        json_mode: bool = False,
+        key: Union[str, List[str]] = 'ENV',
+        org: Optional[Union[str, List[str]]] = None,
+        meta_template: Optional[Dict] = _DEFAULT_META_TEMPLATE,
+        api_base: str = ORCAROUTER_API_BASE,
+        proxies: Optional[Dict] = None,
+        **gen_params,
+    ):
+        super().__init__(
+            model_type=model_type,
+            retry=retry,
+            json_mode=json_mode,
+            key=key,
+            org=org,
+            meta_template=meta_template,
+            api_base=api_base,
+            proxies=proxies,
+            **gen_params,
+        )
+        # Read OrcaRouter keys from the dedicated env var instead of
+        # $OPENAI_API_KEY.
+        if isinstance(key, str):
+            self.keys = [os.getenv(ORCAROUTER_API_KEY_ENV) if key == 'ENV' else key]
+        else:
+            self.keys = key
+
+    def generate_request_data(self, model_type, messages, gen_params, json_mode=False):
+        result = _gateway_request_data(model_type, messages, gen_params, json_mode)
+        if result is not None:
+            return result
+        return super().generate_request_data(model_type, messages, gen_params, json_mode)

--- a/tests/test_llms/test_orcarouter.py
+++ b/tests/test_llms/test_orcarouter.py
@@ -1,0 +1,120 @@
+import os
+import unittest
+from unittest import mock
+
+from lagent.llms.orcarouter import (
+    ORCAROUTER_API_BASE,
+    ORCAROUTER_DEFAULT_MODEL,
+    ORCAROUTER_API_KEY_ENV,
+    AsyncOrcaRouterAPI,
+    OrcaRouterAPI,
+)
+
+
+class FakeResponse:
+
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+class TestOrcaRouterAPI(unittest.TestCase):
+
+    def tearDown(self):
+        os.environ.pop(ORCAROUTER_API_KEY_ENV, None)
+
+    def test_defaults(self):
+        llm = OrcaRouterAPI()
+        self.assertEqual(llm.url, ORCAROUTER_API_BASE)
+        self.assertEqual(llm.model_type, ORCAROUTER_DEFAULT_MODEL)
+
+    def test_key_from_env(self):
+        os.environ[ORCAROUTER_API_KEY_ENV] = 'sk-orca-test'
+        llm = OrcaRouterAPI(key='ENV')
+        self.assertEqual(llm.keys, ['sk-orca-test'])
+
+    def test_explicit_key(self):
+        llm = OrcaRouterAPI(key='sk-orca-explicit')
+        self.assertEqual(llm.keys, ['sk-orca-explicit'])
+
+    def test_generate_request_data_gateway_model(self):
+        llm = OrcaRouterAPI()
+        header, data = llm.generate_request_data(
+            'orcarouter/auto',
+            [{'role': 'user', 'content': 'hi'}],
+            {'max_new_tokens': 512},
+        )
+        self.assertEqual(data['model'], 'orcarouter/auto')
+        self.assertEqual(data['messages'], [{'role': 'user', 'content': 'hi'}])
+        self.assertEqual(data['max_tokens'], 512)
+        self.assertNotIn('response_format', data)
+
+    def test_generate_request_data_json_mode(self):
+        llm = OrcaRouterAPI(json_mode=True)
+        _, data = llm.generate_request_data(
+            'orcarouter/auto',
+            [{'role': 'user', 'content': 'hi'}],
+            {'max_new_tokens': 512},
+            json_mode=True,
+        )
+        self.assertEqual(data['response_format'], {'type': 'json_object'})
+
+    def test_generate_request_data_vendor_qualified_model(self):
+        llm = OrcaRouterAPI()
+        _, data = llm.generate_request_data(
+            'deepseek/deepseek-v4-pro',
+            [{'role': 'user', 'content': 'hi'}],
+            {'max_new_tokens': 512},
+        )
+        self.assertEqual(data['model'], 'deepseek/deepseek-v4-pro')
+
+    def test_generate_request_data_non_gateway_model(self):
+        llm = OrcaRouterAPI()
+        # A model without a gateway prefix is validated by the base wrapper.
+        with self.assertRaises(NotImplementedError):
+            llm.generate_request_data(
+                'not-a-model',
+                [{'role': 'user', 'content': 'hi'}],
+                {'max_new_tokens': 512},
+            )
+
+    @mock.patch('lagent.llms.openai.requests.post')
+    def test_chat(self, mock_post):
+        os.environ[ORCAROUTER_API_KEY_ENV] = 'sk-orca-test'
+        mock_post.return_value = FakeResponse(
+            {'choices': [{'message': {'content': 'ORCA-OK'}}]}
+        )
+        llm = OrcaRouterAPI(key='ENV')
+        ret = llm.chat([{'role': 'user', 'content': 'hi'}])
+        self.assertEqual(ret, 'ORCA-OK')
+        _, kwargs = mock_post.call_args
+        self.assertEqual(kwargs['url'] if 'url' in kwargs else mock_post.call_args[0][0],
+                         ORCAROUTER_API_BASE)
+        self.assertEqual(kwargs['headers']['Authorization'], 'Bearer sk-orca-test')
+
+
+class TestAsyncOrcaRouterAPI(unittest.TestCase):
+
+    def tearDown(self):
+        os.environ.pop(ORCAROUTER_API_KEY_ENV, None)
+
+    def test_defaults(self):
+        llm = AsyncOrcaRouterAPI()
+        self.assertEqual(llm.url, ORCAROUTER_API_BASE)
+        self.assertEqual(llm.model_type, ORCAROUTER_DEFAULT_MODEL)
+
+    def test_key_from_env(self):
+        os.environ[ORCAROUTER_API_KEY_ENV] = 'sk-orca-test'
+        llm = AsyncOrcaRouterAPI(key='ENV')
+        self.assertEqual(llm.keys, ['sk-orca-test'])
+
+    def test_generate_request_data_gateway_model(self):
+        llm = AsyncOrcaRouterAPI()
+        _, data = llm.generate_request_data(
+            'orcarouter/auto',
+            [{'role': 'user', 'content': 'hi'}],
+            {'max_new_tokens': 512},
+        )
+        self.assertEqual(data['model'], 'orcarouter/auto')


### PR DESCRIPTION
## Summary

Add [OrcaRouter](https://www.orcarouter.ai) as a named LLM provider in Lagent, mirroring the existing `GPTAPI` / `AsyncGPTAPI` OpenAI-compatible wrappers.

OrcaRouter is a gateway that fronts open-weight models from many vendors through a single OpenAI-compatible endpoint. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## What changed

- **`lagent/llms/orcarouter.py`** (new): `OrcaRouterAPI` and `AsyncOrcaRouterAPI`, subclasses of `GPTAPI` / `AsyncGPTAPI` with OrcaRouter defaults:
  - base url `https://api.orcarouter.ai/v1/chat/completions`
  - default model `orcarouter/auto` (auto-routed open-weight models on the gateway)
  - reads `ORCAROUTER_API_KEY` (keys start with `sk-orca-`) instead of `OPENAI_API_KEY`
  - accepts gateway aliases (`orcarouter/*`) and vendor-qualified model names (`vendor/model`, e.g. `deepseek/deepseek-v4-pro`) via the generic Chat Completions payload
- **`lagent/llms/__init__.py`**: export the new wrappers.
- **`docs/en/get_started/quickstart.md`**: document the "Using OrcaRouter" section.
- **`tests/test_llms/test_orcarouter.py`** (new): 11 unit tests covering defaults, env-key resolution, payload generation (gateway alias / vendor-qualified / json mode / unsupported model), and a mocked chat call.

## Verification

- `flake8` clean on changed files; `py_compile` passes.
- Unit tests: 11/11 passed.
- Full suite: identical results to clean `main` (7 pre-existing environment/network-dependent failures in `tests/test_actions/*`; `tests/test_agents/test_rewoo.py` fails collection on clean `main` too due to a refactored-out `llm_qa` module — unrelated to this change).
- L3 live test against `https://api.orcarouter.ai/v1` with a real key, through the new provider path:
  - sync chat (`orcarouter/auto`) → `ORCA-OK`
  - async chat → `ORCA-OK`
  - vendor-qualified model `deepseek/deepseek-v4-pro` → `VENDOR-OK`
  - json mode payload generation verified

## Example

```python
import os
os.environ['ORCAROUTER_API_KEY'] = 'sk-orca-...'

from lagent.llms import OrcaRouterAPI
llm = OrcaRouterAPI(model_type='orcarouter/auto', retry=5, max_new_tokens=2048)
print(llm.chat([{'role': 'user', 'content': 'Hello!'}]))
```

Disclosure: I'm an engineer on the OrcaRouter team.
